### PR TITLE
PORTAL-258: Removed News Detail page

### DIFF
--- a/src/components/Layout/LayoutView.js
+++ b/src/components/Layout/LayoutView.js
@@ -10,7 +10,7 @@ import News from '../../pages/news/newsView';
 import Error from '../../pages/error/Error';
 import Search from '../../pages/search/searchView';
 import ScrollButton from '../ScrollButton/ScrollButtonView';
-import NewsDetail from '../../pages/news/newsDetailView';
+// import NewsDetail from '../../pages/news/newsDetailView';
 
 const Layout = () => {
     return (
@@ -24,7 +24,7 @@ const Layout = () => {
           <Route path="/about" element={<About />} />
           <Route path="/news" element={<News />} />
           <Route path="/sitesearch" element={<Search />} />
-          <Route path="/newsdetail/:id" element={<NewsDetail />} />
+          {/* <Route path="/newsdetail/:id" element={<NewsDetail />} /> */}
           <Route path="*" element={<Error />} />
         </Routes>
         <Footer />

--- a/src/pages/landing/landingView.js
+++ b/src/pages/landing/landingView.js
@@ -315,6 +315,10 @@ const LatestUpdatesContainer = styled.div`
       height: 310px;
     }
 
+    .latestUpdatesListTitleContainer {
+      text-decoration: none;
+    }
+
     .latestUpdatesListTitle {
       color: #72F9FB;
       padding: 14px 23px 0 23px;
@@ -605,11 +609,11 @@ const LandingView = () => {
                 const updatekey = `update_${updateidx}`;
                 return (
                   <div className='latestUpdatesListItem' key={updatekey}>
-                    <div className='latestUpdatesListItemPic' style={{ backgroundImage: `url(${updateItem.img})` }} />
-                    <div className='latestUpdatesListTitle'>{updateItem.title}</div>
+                    <a href={`/news/#${updateItem.id}`} ><div className='latestUpdatesListItemPic' style={{ backgroundImage: `url(${updateItem.img})` }} /></a>
+                    <a className='latestUpdatesListTitleContainer' href={`/news/#${updateItem.id}`}><div className='latestUpdatesListTitle'>{updateItem.title}</div></a>
                     <div className='latestUpdatesListContent'>
                       {updateItem.content.slice(0, 130)+'... '}
-                      <a className='readMoreContainer' href={`/newsdetail/${updateItem.id}`}>Read More</a>
+                      <a className='readMoreContainer' href={`/news/#${updateItem.id}`}>Read More</a>
                     </div>
                   </div>
                 )

--- a/src/pages/news/newsView.js
+++ b/src/pages/news/newsView.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef }from 'react';
 import {
   withStyles,
 } from '@material-ui/core';
-import { useNavigate } from 'react-router-dom';
+// import { useNavigate } from 'react-router-dom';
 import ReactHtmlParser from 'html-react-parser';
 import Pagination from '@material-ui/lab/Pagination';
 import styled from 'styled-components';
@@ -83,12 +83,11 @@ const NewsContainer = styled.div`
     padding: 23px 32px 0 38px;
     box-shadow: 0px 4px 24px rgba(0, 0, 0, 0.25);
     text-decoration: none;
-    cursor: pointer;
   }
 
-  .newsItem:hover {
-    border: 1.5px solid #00BDCD;
-  }
+  // .newsItem:hover {
+  //   border: 1.5px solid #00BDCD;
+  // }
 
   .newsItemTextContainer {
     width: 76%;
@@ -175,7 +174,7 @@ const getPageResults = (selectedTab, pageInfo) => {
 }
 
 const NewsView = ({classes}) => {
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
   const [selectedTab, setSelectedTab] = useState("All");
   const newsTabList = ['All', 'Announcements', 'News & Other', 'Application Updates', 'Site Updates'];
   const sizelist = [10,20,50,100];
@@ -240,11 +239,11 @@ const NewsView = ({classes}) => {
     setPageTotal(total);
   };
 
-  const gotoNewsDetail = (e, newsID) => {
-    if (e.target.tagName !== 'A') {
-      navigate(`/newsdetail/${newsID.trim()}`);
-    }
-  };
+  // const gotoNewsDetail = (e, newsID) => {
+  //   if (e.target.tagName !== 'A') {
+  //     navigate(`/newsdetail/${newsID.trim()}`);
+  //   }
+  // };
 
   return (
     <NewsContainer>
@@ -264,7 +263,8 @@ const NewsView = ({classes}) => {
           data.length > 0 ? data.map((newsItem, idx) => {
             const newskey = `news_${idx}`;
             return (
-              <div key={newskey} onClick={(e) => gotoNewsDetail(e, newsItem.id)} className='newsItem'>
+              // <div key={newskey} onClick={(e) => gotoNewsDetail(e, newsItem.id)} className='newsItem'>
+              <div id={newsItem.id} key={newskey} className='newsItem'>
                 <div className='newsItemTextContainer'>
                   <div className='newsItemTitle'>{newsItem.title}</div>
                   <div className='newsItemDate'>{newsItem.date}</div>


### PR DESCRIPTION
Home page
Update the Home page so that the Latest Updates 'Read More >' links go to that topic on the news main page not a details page

News Main page
Update the news items so that they no longer link to a details page.

News Details page
Removed all of these pages.