### PR TITLE
PORTAL-276: Stats Bar - NCCR update

### DIFF
--- a/src/bento/landingPageData.js
+++ b/src/bento/landingPageData.js
@@ -42,8 +42,8 @@ export const statsData = [
     detail: 'Molecular Targets Platform',
   },
   {
-    num: '218,246',
-    title: 'Cases',
+    num: '1,496,577',
+    title: 'Reported Cases',
     detail: 'National Childhood Cancer Registry Explorer',
   },
 ];


### PR DESCRIPTION
Update the NCCR item in the Stats at a Glance bar...

to read 'Reported Cases.'  Currently it reads 'Cases.' to be '1,496,577.' Currently it reads '218,246.'