### PR TITLE
PORTAL-637: Go to Cart > link does not work

### DIFF
--- a/src/pages/inventory/tabs/wrapperConfig/Wrapper.js
+++ b/src/pages/inventory/tabs/wrapperConfig/Wrapper.js
@@ -83,7 +83,7 @@ export const wrapperConfig = [{
     {
       title: 'Go to Cart >',
       clsName: 'go_to_cart',
-      url: '#/fileCentricCart',
+      url: '/fileCentricCart',
       type: types.LINK,
     }],
 },


### PR DESCRIPTION
The link should be https://ccdi-dev.cancer.gov/fileCentricCart