### PR TITLE
PORTAL-634: Inventory Explore Infographics: Missing unit specification for age ranges in the Diagnosis Age histogram chart

### DIFF
--- a/src/bento/dashTemplate.js
+++ b/src/bento/dashTemplate.js
@@ -784,13 +784,13 @@ export const widgetConfig = [
   },
   {
     type: 'donut',
-    title: 'Diagnosis',
+    title: 'Diagnosis (ICD-O Morphology)',
     dataName: 'participantCountByDiagnosis',
     sliceTitle: 'Participants',
   },
   {
     type: 'bar',
-    title: 'Diagnosis Age',
+    title: 'Age at Diagnosis (years)',
     dataName: 'participantCountByDiagnosisAge',
     width: '100%',
     height: 210,

--- a/src/bento/dashTemplate.js
+++ b/src/bento/dashTemplate.js
@@ -784,7 +784,7 @@ export const widgetConfig = [
   },
   {
     type: 'donut',
-    title: 'Diagnosis (ICD-O Morphology)',
+    title: 'Diagnosis (ICD-O)',
     dataName: 'participantCountByDiagnosis',
     sliceTitle: 'Participants',
   },


### PR DESCRIPTION
The title of the histogram chart should clearly specify the unit as "Age at Diagnosis(years)"
The title of the diagnosis donut chart shows as "Diagnosis (ICD-O)"