### PR TITLE
PORTAL-738: Results pane "Studies" Tab has typo in 'Principle Investigator'

### DIFF
--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -1293,7 +1293,7 @@ export const tabContainers = [
       },
       {
         dataField: 'personnel_name',
-        header: 'Principle Investigator(s)',
+        header: 'Principal Investigator(s)',
         display: true,
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,


### PR DESCRIPTION
changed column name from "Principle Investigator(s)" to "Principal Investigator(s)"