### PR TITLE
PORTAL-690: Study Tab, Remove Study Accession Column

### DIFF
--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -1278,13 +1278,6 @@ export const tabContainers = [
         role: cellTypes.DISPLAY,
       },
       {
-        dataField: 'phs_accession',
-        header: 'Study Accession',
-        display: true,
-        tooltipText: 'sort',
-        role: cellTypes.DISPLAY,
-      },
-      {
         dataField: 'study_short_title',
         header: 'Study Short Title',
         display: true,


### PR DESCRIPTION
This column is redundant with the Study ID column and currently provides the same information.