### PR TITLE
PORTAL-836: Hub Homepage and Menu Bar Update

### DIFF
--- a/src/bento/globalHeaderData.js
+++ b/src/bento/globalHeaderData.js
@@ -83,11 +83,6 @@ Applications: [
     name:'National Childhood Cancer Registry Explorer',
     link: '/#nccr',
     className: 'navMobileSubItem',
-  },
-  {
-    name:'Childhood Cancer Data Initiative Data Inventory',
-    link: '/#inventory',
-    className: 'navMobileSubItem',
   }],
 "Other Resources": [
   {

--- a/src/bento/landingPageData.js
+++ b/src/bento/landingPageData.js
@@ -25,8 +25,8 @@ export const introData = {
 
 export const titleData = {
   latestUpdatesTitle: 'Latest Updates',
-  resourceTitle: 'Explore',
-  applicationsTitle: 'CCDI APPLICATIONS',
+  resourceTitle: 'RESOURCES',
+  applicationsTitle: 'CCDI-SUPPORTED RESOURCES',
   cloudResourcesTitle: 'OTHER RESOURCES',
   aboutTitle: 'About the CCDI Community',
 };
@@ -89,13 +89,6 @@ export const resourcesAppliationsListData = [
     subtitle: 'NCCR Explorer',
     content: 'A tool to browse demographic, incidence, and survival statistics for cancers in children, adolescent, and young adults.',
     link: 'https://nccrexplorer.ccdi.cancer.gov',
-  },
-  {
-    id: 'inventory',
-    title: 'Childhood Cancer Data Initiative Data Inventory',
-    subtitle: 'CCDI Data Inventory',
-    content: 'A searchable catalog of annotated data submissions at the participant-level, serving as the primary CCDI data reference.',
-    link: '/explore',
   },
 ];
 


### PR DESCRIPTION
Remove 'Childhood Cancer Data Initiative Data Inventory' from the 'Applications' menu dropdown Update the homepage 'Explore' section to be 'Resources' Update sub-section 'CCDI Applications' to be 'CCDI-Supported Resources' Remove 'Childhood Cancer Data Initiative Data Inventory' from section.