### PR TITLE
PORTAL-2265: Implement visual indicator for facet selections in frozen facet pane

### DIFF
--- a/src/pages/inventory/inventoryStyle.js
+++ b/src/pages/inventory/inventoryStyle.js
@@ -102,6 +102,15 @@ export default () => ({
       padding: '0 4px',
     }
   },
+  activeFilterLegend: {
+    color: '#9CE1E5',
+    margin: '0 16px',
+    padding: '16px 0',
+    fontStyle: 'italic',
+    '& svg': {
+      marginRight: '8px',
+    }
+  },
   sideBarCover: {
     marginLeft: '-100px',
     width: '100px',

--- a/src/pages/inventory/inventoryStyle.js
+++ b/src/pages/inventory/inventoryStyle.js
@@ -86,6 +86,22 @@ export default () => ({
     margin: 'auto',
     borderLeft: 'thin solid #8A7F7C',
   },
+  activeFiltersCount: {
+    color: '#ffffff',
+    textAlign: 'center',
+    display: 'flex',
+    justifyContent: 'space-evenly',
+    alignItems: 'center',
+    padding: '8px 0',
+    margin: '0 8px',
+    borderTop: '#ADADAD 0.5px solid',
+    '& span': {
+      color: '#ffffff',
+      fontSize: '11px',
+      border: '0.5px solid #ffffff',
+      padding: '0 4px',
+    }
+  },
   sideBarCover: {
     marginLeft: '-100px',
     width: '100px',
@@ -142,13 +158,11 @@ export default () => ({
   },
   categoryTitle: {
     color: '#000000',
-    display: 'flex',
-    zIndex: 2,
     fontSize: '18.5px',
-    alignItems: 'center',
     fontFamily: 'Poppins',
     fontWeight: 500,
     marginLeft: '3px',
+    marginRight: '6px',
     letterSpacing: '-0.02em',
     justifyContent: 'space-between',
     textTransform: 'uppercase',

--- a/src/pages/inventory/inventoryView.js
+++ b/src/pages/inventory/inventoryView.js
@@ -206,7 +206,6 @@ const Inventory = ({
                 </span>
               </div>
               <ULSection className={classes.siderContent}>
-    
                 {
                   sectionList.map((category, idx) => {
                     return (
@@ -232,6 +231,12 @@ const Inventory = ({
                   })
                 }
               </ULSection>
+              <div className={classes.activeFilterLegend}>
+                <svg width="9" height="9" viewBox="0 0 9 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="4.5" cy="4.5" r="4.5" fill="#9CE1E5" />
+                </svg>
+                <span>denotes facet(s) selected</span>
+              </div>
             </div>
           </div>
           {

--- a/src/pages/inventory/inventoryView.js
+++ b/src/pages/inventory/inventoryView.js
@@ -16,7 +16,7 @@ import {
 } from '@bento-core/local-find';
 import store from '../../store';
 import { generateQueryStr } from '@bento-core/util';
-import { resetIcon, queryParams, facetsConfig } from '../../bento/dashTemplate';
+import { resetIcon, queryParams, facetsConfig, sectionLabel } from '../../bento/dashTemplate';
 import styles from './inventoryStyle';
 import NewBentoFacetFilter from './sideBar/NewBentoFacetFilter';
 import WidgetView from './widget/WidgetView';
@@ -58,6 +58,21 @@ const RightContentPanel = styled.div`
   border-left: thin solid #8A7F7C;
   transition: all .5s;
 `;
+
+const getDividerColor = (index) => {
+  const colors = [
+    '#4D889E', // divider0
+    '#974599', // divider1
+    '#4150A4', // divider2
+    '#E9B34A', // divider3
+    '#CD5C4E', // divider4
+    '#1F6BBF', // divider5
+    '#60C4A1', // divider6
+    '#357288', // divider7
+    '#974599', // divider8
+  ];
+  return colors[index % colors.length]; // Use modulo to cycle through colors if needed
+};
 
 const Inventory = ({
   classes,
@@ -184,10 +199,14 @@ const Inventory = ({
                 Component={CustomClearAllFiltersBtn}
                 activeFilters={activeFilters}
               />
-              <ULSection className={classes.siderContent}>
+              <div className={classes.activeFiltersCount}>
+                Total Filters Selected:
                 <span>
                   {activeFiltersCount}
                 </span>
+              </div>
+              <ULSection className={classes.siderContent}>
+    
                 {
                   sectionList.map((category, idx) => {
                     return (
@@ -195,8 +214,16 @@ const Inventory = ({
                       <Divider className={`${classes.divider} divider${idx}`}/>
                       <li onClick={() => handleCategoryClick(idx)}>
                         <div className={classes.categoryContainer}>
-                          <span className={classes.categoryTitle}>{category}</span>
-                          <span className={classes.categoryCount}>{sectionCount[category] !== 0 ? '*': ''}</span>
+                          <div>
+                            <span className={classes.categoryTitle}>{sectionLabel[category] !== undefined ? sectionLabel[category] : category}</span>
+                            <span className={classes.categoryCount}>
+                              {sectionCount[category] !== 0 ? (
+                                <svg width="9" height="9" viewBox="0 0 9 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                  <circle cx="4.5" cy="4.5" r="4.5" fill={getDividerColor(idx)} />
+                                </svg>
+                              ) : ''}
+                            </span>
+                          </div>
                           {selectedSection === idx && <img src={vectorIcon} alt="vector" className={classes.categoryIcon} />}
                         </div>
                       </li>

--- a/src/pages/inventory/inventoryView.js
+++ b/src/pages/inventory/inventoryView.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState , useMemo } from 'react';
 import {
   NavLink,
   useLocation,
@@ -66,8 +66,41 @@ const Inventory = ({
 }) => {
   const [selectedSection, setSelectedSection] = useState(-1);
 
-  const sectionList = [...new Set(facetsConfig.map((item) => item.section))];
+  // Calculate filter-related counts and lists using memoization for performance
+  const {
+    activeFiltersCount, // Total number of active filters across all sections
+    sectionList,        // List of unique section names from facet config
+    sectionCount        // Count of active filters per section
+  } = useMemo(() => {
+    // Return empty values if facet config is missing
+    if (!facetsConfig || !facetsConfig.length) {
+      return { activeFiltersCount: 0, sectionList: [], sectionCount: {} };
+    }
   
+    // Create list of sections with their active filter counts
+    const facetsConfigList = facetsConfig.map(item => ({
+      section: item.section,
+      datafield: item.datafield,
+      // Count number of active filters for this facet's datafield
+      count: (activeFilters && activeFilters[item.datafield] ? activeFilters[item.datafield].length : 0)
+    }));
+  
+    // Get unique list of section names
+    const sectionList = [...new Set(facetsConfig.map(item => item.section))];
+    
+    // Calculate total number of active filters across all sections
+    const activeFiltersCount = Object.values(activeFilters || {})
+      .reduce((sum, array) => sum + array.length, 0);
+  
+    // Calculate total active filters per section
+    const sectionCount = facetsConfigList.reduce((acc, item) => {
+      acc[item.section] = (acc[item.section] || 0) + item.count;
+      return acc;
+    }, {});
+  
+    return { activeFiltersCount, sectionList, sectionCount };
+  }, [facetsConfig, activeFilters]); // Only recalculate when these dependencies change
+
   /**
     * Clear All Filter Button
     * Custom button component
@@ -152,6 +185,9 @@ const Inventory = ({
                 activeFilters={activeFilters}
               />
               <ULSection className={classes.siderContent}>
+                <span>
+                  {activeFiltersCount}
+                </span>
                 {
                   sectionList.map((category, idx) => {
                     return (
@@ -160,6 +196,7 @@ const Inventory = ({
                       <li onClick={() => handleCategoryClick(idx)}>
                         <div className={classes.categoryContainer}>
                           <span className={classes.categoryTitle}>{category}</span>
+                          <span className={classes.categoryCount}>{sectionCount[category] !== 0 ? '*': ''}</span>
                           {selectedSection === idx && <img src={vectorIcon} alt="vector" className={classes.categoryIcon} />}
                         </div>
                       </li>

--- a/src/pages/inventory/widget/WidgetView.js
+++ b/src/pages/inventory/widget/WidgetView.js
@@ -111,7 +111,7 @@ const WidgetView = ({
         </div>
       </div>
       <Collapse in={collapse} className={classes.backgroundWidgets}>
-        <Grid container>
+        <Grid container style={{ minWidth: '990px' }}>
           {config.slice(0, 6).map((widget, index) => {
             const dataset = displayWidgets[widget.dataName];
             if (!dataset || dataset.length === 0) {


### PR DESCRIPTION
This pull request updates the inventory UI to provide clearer feedback about active filters and improve section labeling. The main changes include displaying the total number of active filters, showing per-section filter counts with visual indicators, supporting custom section labels, and refining styles for these new elements.

**Filter feedback and indicators:**
* Added a display for the total number of active filters selected at the top of the sidebar for immediate user feedback. [[1]](diffhunk://#diff-7334e27f91813d9c4993a809eb90faa8b83e3f7a43fe1aa636e18fc9d375f6a5R202-R207) [[2]](diffhunk://#diff-7adc4d62bdd16508039d8d2a56cff63bfd81002f8fef93f51b3ff44f705d64f3R89-R113)
* Implemented per-section filter count indicators: each section now shows a colored dot when filters are active, with the color determined by its position. [[1]](diffhunk://#diff-7334e27f91813d9c4993a809eb90faa8b83e3f7a43fe1aa636e18fc9d375f6a5R62-R117) [[2]](diffhunk://#diff-7334e27f91813d9c4993a809eb90faa8b83e3f7a43fe1aa636e18fc9d375f6a5L162-R225)
* Added a legend explaining the meaning of the colored dot indicator for selected facets. [[1]](diffhunk://#diff-7adc4d62bdd16508039d8d2a56cff63bfd81002f8fef93f51b3ff44f705d64f3R89-R113) [[2]](diffhunk://#diff-7334e27f91813d9c4993a809eb90faa8b83e3f7a43fe1aa636e18fc9d375f6a5R234-R239)

**Section labeling improvements:**
* Section names in the sidebar now use custom labels from `sectionLabel` if available, improving readability and flexibility. [[1]](diffhunk://#diff-7334e27f91813d9c4993a809eb90faa8b83e3f7a43fe1aa636e18fc9d375f6a5L19-R19) [[2]](diffhunk://#diff-7334e27f91813d9c4993a809eb90faa8b83e3f7a43fe1aa636e18fc9d375f6a5L162-R225)

**Styling refinements:**
* Introduced new styles for active filter counts, legend, and improved spacing for section titles to match the new UI elements. [[1]](diffhunk://#diff-7adc4d62bdd16508039d8d2a56cff63bfd81002f8fef93f51b3ff44f705d64f3R89-R113) [[2]](diffhunk://#diff-7adc4d62bdd16508039d8d2a56cff63bfd81002f8fef93f51b3ff44f705d64f3L145-R174)