### PR TITLE
PORTAL-2254: Add new links from Hub to CCDI cBioPortal

### DIFF
--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -239,8 +239,13 @@ const StudiesDetail = ({data}) => {
                         </div>
                     </div>
                     <div className='studyItem'>
-                        <div className='studyItemTitle'>Download</div>
-                        <div className="studyItemContent"><a href={studyDownloadLinks[data.study_id]}>Study Manifest<img className='studyManifestIcon' src={manifestIcon} alt="manifestIcon" /></a></div>
+                        <div className='studyItemTitle'>Access Data</div>
+                        <div className="studyItemContent">
+                            <a href={studyDownloadLinks[data.study_id]}>Download Study Manifest<img className='studyManifestIcon' src={manifestIcon} alt="manifestIcon" /></a>
+                            {data.study_id === 'phs002790' && <>
+                                <br/><a href="https://cbioportal.ccdi.cancer.gov/" target="_blank" rel="noopener noreferrer">View in CCDI cBioPortal Data Explorer<img className='exportIcon' src={exportIcon} alt="exportIcon" /></a>
+                            </>}
+                        </div>
                     </div>
                 </div>
                 <div className='rightContainer'>


### PR DESCRIPTION
This pull request updates the "Download" section in the study details view to improve clarity and provide additional access options for a specific study. The most important changes are:

* Renamed the section title from "Download" to "Access Data" for better clarity.

* Updated the download link description to "Download Study Manifest" for improved specificity.

* For the study with `study_id` equal to `'phs002790'`, added a new link that allows users to view the study in the CCDI cBioPortal Data Explorer, including an export icon for visual context.
