### PR TITLE
PORTAL-2272:  Design QA fixes - Study Details Page

### DIFF
--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -69,7 +69,7 @@ const StudiesDetailContainer = styled.div`
         font-weight: 300;
         line-height: 38px;
         letter-spacing: 0.7px;
-        padding: 15px 0 15px 36px;
+        padding: 13px 0 13px 36px;
     }
 
     .studyIdText {

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -15,7 +15,7 @@ const StudiesDetailContainer = styled.div`
         font-weight: 400;
         font-size: 16px;
         line-height: 162%;
-        margin-left: 32px;
+        padding-left: 30px;
         padding-top: 8px;
         padding-bottom: 8px;
 
@@ -115,7 +115,7 @@ const StudiesDetailContainer = styled.div`
 
     @media (min-width: 1420px) {
         .breadcrumb {
-            width: 1350px;
+            width: 1420px;
             margin: 0 auto;
         }
         .resourceTitle {

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -152,7 +152,7 @@ const StudiesDetailBodyContainer = styled.div`
     }
 
     .studyItemTitle {
-        color: #0095A2;
+        color: #00818D;
         font-family: Poppins;
         font-size: 16px;
         font-weight: 500;


### PR DESCRIPTION
This pull request makes several small adjustments to the styling of the study detail page to improve layout consistency and visual appearance. The changes mainly involve tweaks to paddings, widths, and colors in the styled components.

Acceptance Criteria:

50 Breadcrumb should be aligned with Nav
51 Height of banner should be 64px instead of 68px
52 Replace non-508 compliant color with #00818D (updated on design- prev was #0095A2)

Layout and spacing adjustments:

* Changed `.breadcrumb` width from `1350px` to `1420px` for screens wider than 1420px, ensuring better alignment on large displays.
* Updated padding and margin for elements within `StudiesDetailContainer` to improve spacing: replaced `margin-left` with `padding-left` and slightly reduced vertical padding on certain elements. [[1]](diffhunk://#diff-3bd968a16442472a3716461488df94a3f23c5e28a570f1b30ca5182057299850L18-R18) [[2]](diffhunk://#diff-3bd968a16442472a3716461488df94a3f23c5e28a570f1b30ca5182057299850L72-R72)

Visual design update:

* Changed `.studyItemTitle` color from `#0095A2` to a slightly darker `#00818D` for improved visual contrast.