### PR TITLE
PORTAL-2322:  Implement - Federation DMN

### DIFF
--- a/public/injectEnv.js
+++ b/public/injectEnv.js
@@ -10,5 +10,6 @@ window.injectedEnv = {
   REACT_APP_FILE_SERVICE_API: 'https://bento-tools.org/v1/graphql/',
   REACT_APP_INTEROP_SERVICE_API: 'https://ccdi-dev.cancer.gov/api/interoperation/',
   REACT_APP_DMN_URL: 'https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/ccdi-model/refs/heads/dmn-dev/model-desc/',
+  REACT_APP_FED_DMN_URL: 'https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/ccdi-federation-dmn/refs/heads/main/',
   REACT_APP_STATIC_CONTENT_URL: 'https://raw.githubusercontent.com/CBIIT/CCDI_Hub_Static_Contents/dev',
 };

--- a/public/injectEnv.js
+++ b/public/injectEnv.js
@@ -10,6 +10,5 @@ window.injectedEnv = {
   REACT_APP_FILE_SERVICE_API: 'https://bento-tools.org/v1/graphql/',
   REACT_APP_INTEROP_SERVICE_API: 'https://ccdi-dev.cancer.gov/api/interoperation/',
   REACT_APP_DMN_URL: 'https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/ccdi-model/refs/heads/dmn-dev/model-desc/',
-  REACT_APP_FED_DMN_URL: 'https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/ccdi-federation-dmn/refs/heads/main/',
   REACT_APP_STATIC_CONTENT_URL: 'https://raw.githubusercontent.com/CBIIT/CCDI_Hub_Static_Contents/dev',
 };

--- a/src/bento/globalHeaderData.js
+++ b/src/bento/globalHeaderData.js
@@ -109,6 +109,11 @@ export const navbarSublists = {
     link: 'https://nccrdataplatform.ccdi.cancer.gov/home',
     className: 'navMobileSubItem',
   },
+  {
+    name:'Federation Data Model',
+    link: '/federation-data-model',
+    className: 'navMobileSubItem',
+  },  
   // {
   //   name:'Cancer Genomics Cloud',
   //   link: 'https://www.cancergenomicscloud.org',

--- a/src/components/Layout/LayoutView.js
+++ b/src/components/Layout/LayoutView.js
@@ -16,6 +16,7 @@ import Cart from '../../pages/cart/cartController';
 import ScrollButton from '../ScrollButton/ScrollButtonView';
 import MCIResourceView from '../../pages/resource/MCIResourcePage/MCIResourceController'
 import FederationResourceView from "../../pages/resource/FederationResourcePage/FederationResourceController";
+import FederationDataModelNavigator from "../../pages/resource/FederationDMN/FederationDMN";
 import CPIResourceView from "../../pages/resource/CPIResourcePage/CPIResourceController";
 // import CBioPortalResourceView from "../../pages/resource/cBioPortalResourcePage/cBioPortalResourceController";
 import ReleaseNotesPageView from '../../pages/releaseNotePage/releaseNotePageController';
@@ -44,6 +45,7 @@ const Layout = () => {
           <Route path="/fileCentricCart" element={<Cart />} />
           <Route path="/MCI" element={<MCIResourceView />} />
           <Route path="/data-federation-resource" element={<FederationResourceView/>} />
+          <Route path="/federation-data-model" element={<FederationDataModelNavigator />} />
           <Route path="/data-usage-policies" element={<DataUsagePoliciesView />} />
           <Route path="/ccdi-participant-index" element={<CPIResourceView />} />
           <Route path="/publications" element={<PublicationsView />} />

--- a/src/pages/resource/FederationDMN/FederationDMN.js
+++ b/src/pages/resource/FederationDMN/FederationDMN.js
@@ -3,7 +3,10 @@ import React from 'react';
 import env from '../../../utils/env';
 
 const FederationDataModelNavigator = () => {
-  const fedDmnUrl = env.REACT_APP_FED_DMN_URL  || "https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/ccdi-federation-dmn/refs/heads/main/";
+  const dmnUrl = (env.REACT_APP_DMN_URL || "https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/ccdi-model/refs/heads/dmn-dev/model-desc/").split('?config=')[0] + '?config=';
+
+  const fedDmnUrl = dmnUrl + 'https://raw.githubusercontent.com/CBIIT/ccdi-federation-dmn/refs/heads/main/';
+  
   return (
     <div style={{ width: '100%', height: '1000px' }}>
       <iframe

--- a/src/pages/resource/FederationDMN/FederationDMN.js
+++ b/src/pages/resource/FederationDMN/FederationDMN.js
@@ -8,33 +8,30 @@ import env from '../../../utils/env';
  * with environment-specific configuration URLs.
  */
 const FederationDataModelNavigator = () => {
+  // Configuration constants
+  const DEFAULT_DMN_URL = "https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/ccdi-model/refs/heads/dmn-dev/model-desc/";
+  const FED_DMN_BASE_URL = "https://raw.githubusercontent.com/CBIIT/ccdi-federation-dmn/refs/heads/";
+  
   // Get the base DMN URL from environment variables or use default
-  const BASE_URL = env.REACT_APP_DMN_URL || "https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/ccdi-model/refs/heads/dmn-dev/model-desc/";
+  const baseUrl = env.REACT_APP_DMN_URL || DEFAULT_DMN_URL;
+  
+  // Extract environment from URL (e.g., "dev" from "dmn-dev")
+  const match = baseUrl.match(/refs\/heads\/dmn-([^\/]+)/);
+  const baseEnv = match && match[1] || 'dev';
   
   // Remove any existing config parameter to get clean base URL
-  const CLEAN_BASE_URL = BASE_URL.split('?config=')[0];
+  const cleanBaseUrl = baseUrl.split('?config=')[0];
 
   /**
    * Constructs the Federation DMN URL with environment-specific configuration
    * @returns {string} Complete URL with config parameter pointing to the appropriate branch
    */
   const getFedDmnUrl = () => {
-    // Map environment names to their corresponding GitHub branch names
-    const envFedBranches = {
-      development: 'fed-dev',
-      qa: 'fed-qa',
-      staging: 'fed-stage',
-      production: 'fed-prod'
-    };
-
-    // Get the branch name for the current environment, default to development
-    const branch = envFedBranches[env.NODE_ENV] || envFedBranches.development;
-    
-    // Construct the full GitHub raw content URL for the federation DMN config
-    const configUrl = `https://raw.githubusercontent.com/CBIIT/ccdi-federation-dmn/refs/heads/${branch}/`;
+    // Construct the federation DMN config URL for the current environment
+    const fedConfigUrl = `${FED_DMN_BASE_URL}fed-${baseEnv}/`;
     
     // Return the complete DMN URL with the config parameter
-    return `${CLEAN_BASE_URL}?config=${configUrl}`;
+    return `${cleanBaseUrl}?config=${fedConfigUrl}`;
   };
 
   // Get the complete DMN URL with the config parameter

--- a/src/pages/resource/FederationDMN/FederationDMN.js
+++ b/src/pages/resource/FederationDMN/FederationDMN.js
@@ -1,0 +1,20 @@
+
+import React from 'react';
+import env from '../../../utils/env';
+
+const FederationDataModelNavigator = () => {
+  const fedDmnUrl = env.REACT_APP_FED_DMN_URL  || "https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/ccdi-federation-dmn/refs/heads/main/";
+  return (
+    <div style={{ width: '100%', height: '1000px' }}>
+      <iframe
+        src={fedDmnUrl}
+        scrolling="no"
+        title="Federation Data Model Navigator"
+        style={{ width: '100%', height: '1000px', border: 'none' }}
+        sandbox="allow-popups allow-scripts allow-same-origin allow-downloads"
+      />
+    </div>
+  );
+};
+
+export default FederationDataModelNavigator;

--- a/src/pages/resource/FederationDMN/FederationDMN.js
+++ b/src/pages/resource/FederationDMN/FederationDMN.js
@@ -2,11 +2,43 @@
 import React from 'react';
 import env from '../../../utils/env';
 
+/**
+ * FederationDataModelNavigator component
+ * Renders an iframe displaying the CCDI Federation Data Model Navigator
+ * with environment-specific configuration URLs.
+ */
 const FederationDataModelNavigator = () => {
-  const dmnUrl = (env.REACT_APP_DMN_URL || "https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/ccdi-model/refs/heads/dmn-dev/model-desc/").split('?config=')[0] + '?config=';
-
-  const fedDmnUrl = dmnUrl + 'https://raw.githubusercontent.com/CBIIT/ccdi-federation-dmn/refs/heads/main/';
+  // Get the base DMN URL from environment variables or use default
+  const BASE_URL = env.REACT_APP_DMN_URL || "https://cbiit.github.io/crdc-data-model-navigator/?config=https://raw.githubusercontent.com/CBIIT/ccdi-model/refs/heads/dmn-dev/model-desc/";
   
+  // Remove any existing config parameter to get clean base URL
+  const CLEAN_BASE_URL = BASE_URL.split('?config=')[0];
+
+  /**
+   * Constructs the Federation DMN URL with environment-specific configuration
+   * @returns {string} Complete URL with config parameter pointing to the appropriate branch
+   */
+  const getFedDmnUrl = () => {
+    // Map environment names to their corresponding GitHub branch names
+    const envFedBranches = {
+      development: 'fed-dev',
+      qa: 'fed-qa',
+      staging: 'fed-stage',
+      production: 'fed-prod'
+    };
+
+    // Get the branch name for the current environment, default to development
+    const branch = envFedBranches[env.NODE_ENV] || envFedBranches.development;
+    
+    // Construct the full GitHub raw content URL for the federation DMN config
+    const configUrl = `https://raw.githubusercontent.com/CBIIT/ccdi-federation-dmn/refs/heads/${branch}/`;
+    
+    // Return the complete DMN URL with the config parameter
+    return `${CLEAN_BASE_URL}?config=${configUrl}`;
+  };
+
+  const fedDmnUrl = getFedDmnUrl();
+
   return (
     <div style={{ width: '100%', height: '1000px' }}>
       <iframe

--- a/src/pages/resource/FederationDMN/FederationDMN.js
+++ b/src/pages/resource/FederationDMN/FederationDMN.js
@@ -37,6 +37,7 @@ const FederationDataModelNavigator = () => {
     return `${CLEAN_BASE_URL}?config=${configUrl}`;
   };
 
+  // Get the complete DMN URL with the config parameter
   const fedDmnUrl = getFedDmnUrl();
 
   return (

--- a/src/pages/resource/FederationDMN/FederationDMN.js
+++ b/src/pages/resource/FederationDMN/FederationDMN.js
@@ -31,7 +31,7 @@ const FederationDataModelNavigator = () => {
     const fedConfigUrl = `${FED_DMN_BASE_URL}fed-${baseEnv}/`;
     
     // Return the complete DMN URL with the config parameter
-    return `${cleanBaseUrl}?config=${fedConfigUrl}`;
+    return `${cleanBaseUrl}?config=${encodeURIComponent(fedConfigUrl)}`;
   };
 
   // Get the complete DMN URL with the config parameter


### PR DESCRIPTION
This pull request adds a new "Federation Data Model Navigator" feature to the application, making it accessible from the global navigation and routing system. The main change introduces a new page that displays the Federation Data Model Navigator in an iframe, with dynamic environment-based configuration. The routing and navigation are updated to support this new page.

**New Federation Data Model Navigator feature:**

* Added a new `FederationDataModelNavigator` component (`src/pages/resource/FederationDMN/FederationDMN.js`) that renders an iframe for the CCDI Federation Data Model Navigator, with environment-specific configuration URLs.

**Navigation and routing updates:**

* Added a "Federation Data Model" item to the global navigation sublist (`src/bento/globalHeaderData.js`) to make the page accessible from the main menu.
* Imported the new `FederationDataModelNavigator` component into the layout (`src/components/Layout/LayoutView.js`).
* Added a new route for `/federation-data-model` to render the Federation Data Model Navigator page (`src/components/Layout/LayoutView.js`).