### PR TITLE
PORTAL-2384 - Add "View in CCDI cBioPortal Data Explorer" button for multiple studies

### DIFF
--- a/src/bento/studiesData.js
+++ b/src/bento/studiesData.js
@@ -36,6 +36,24 @@ const studyDownloadLinks = {
   "phs003519": "https://d2xnga7irezzit.cloudfront.net/metadata_files/phs003519_CCDI_Study_Manifest_v3.1.0.xlsx",
 };
 
+const studycBioPortalLinks = {
+  'phs000463': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000463',
+  'phs000464': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000464',
+  'phs000465': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000465',
+  'phs000466': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000466',
+  'phs000467': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000467',
+  'phs000468': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000468',
+  'phs000470': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000470',
+  'phs000471': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000471',
+  'phs001437': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs001437',
+  'phs002276': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs002276',
+  'phs002517': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs002517',
+  'phs002790': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs002790',
+  'phs002883': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs002883',
+  'phs003432': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs003432'
+};
+
+
 export async function openDoubleLink(url, fileName) {
   let urlContent = await fetch(url);
   if (urlContent.ok) {
@@ -139,5 +157,6 @@ export {
   table,
   GET_STUDIES_DATA_QUERY,
   GET_NUMBER_OF_STUDIES,
-  studyDownloadLinks
+  studyDownloadLinks,
+  studycBioPortalLinks
 };

--- a/src/pages/studyDetail/overview/overviewView.js
+++ b/src/pages/studyDetail/overview/overviewView.js
@@ -2,12 +2,13 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import exportIcon from '../../../assets/studies/exportIcon.svg';
 import manifestIcon from '../../../assets/studies/manifestIcon.svg';
-import { studyDownloadLinks } from '../../../bento/studiesData';
+import { studyDownloadLinks, studycBioPortalLinks } from '../../../bento/studiesData';
 import TabsView from './tabs/TabsView';
 import ModalView from './modal/ModalView';
 import { styles } from './overviewStyle';
 
 const OverviewView = ({ data, classes }) => {
+    console.log(data);
     return (
         <div className={classes.container}>
             {/* Left Container for Study Details */}
@@ -56,9 +57,9 @@ const OverviewView = ({ data, classes }) => {
                             Download Study Manifest
                             <img className={classes.studyManifestIcon} src={manifestIcon} alt="manifestIcon" />
                         </a>
-                        {data.study_id === 'phs002790' && <>
+                        {studycBioPortalLinks[data.study_id] && <>
                             <br/>
-                            <a href="https://cbioportal.ccdi.cancer.gov/" target="_blank" rel="noopener noreferrer">
+                            <a href={studycBioPortalLinks[data.study_id]} target="_blank" rel="noopener noreferrer">
                                 View in CCDI cBioPortal Data Explorer
                                 <img className={classes.exportIcon} src={exportIcon} alt="exportIcon" />
                             </a>


### PR DESCRIPTION
Introduced a new mapping for cBioPortal links in studiesData.js and updated the overview view to display a cBioPortal link for studies that have an entry in the mapping. This allows users to directly access the relevant study in the CCDI cBioPortal Data Explorer from the study detail page.