### PR TITLE
PORTAL-2333: Facet pane sub-facets remain open across pane switches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "7.2.2",
         "@bento-core/cart": "1.0.1-ccdihub.9",
         "@bento-core/data-table": "^1.0.0",
-        "@bento-core/facet-filter": "1.0.1-ccdihub.37",
+        "@bento-core/facet-filter": "1.0.1-ccdihub.39",
         "@bento-core/global-search": "1.0.1-ccdihub.5",
         "@bento-core/local-find": "1.0.1-ccdihub.11",
         "@bento-core/paginated-table": "1.0.1-ccdihub.150",
@@ -1535,9 +1535,9 @@
       }
     },
     "node_modules/@bento-core/facet-filter": {
-      "version": "1.0.1-ccdihub.37",
-      "resolved": "https://registry.npmjs.org/@bento-core/facet-filter/-/facet-filter-1.0.1-ccdihub.37.tgz",
-      "integrity": "sha512-o8/8qlzgeNk3A7hZhhQwmdwyat3qVYlBNbdJ9695xm7u8QzR/u+V6tni9YfGy0FngdnuHQekz/pt+/ds+Tn41A==",
+      "version": "1.0.1-ccdihub.39",
+      "resolved": "https://registry.npmjs.org/@bento-core/facet-filter/-/facet-filter-1.0.1-ccdihub.39.tgz",
+      "integrity": "sha512-0dYGeep7PAKJgzlm5QY/WjqD8IY3Ju/r+Pt7kW9FZmaevcU3yZxx58Pek7wUmfR8gJu92FEq61AGHDcnlACh8g==",
       "dependencies": {
         "@bento-core/util": "1.0.1-ccdihub.1",
         "lodash": "^4.17.20"
@@ -36490,9 +36490,9 @@
       }
     },
     "@bento-core/facet-filter": {
-      "version": "1.0.1-ccdihub.37",
-      "resolved": "https://registry.npmjs.org/@bento-core/facet-filter/-/facet-filter-1.0.1-ccdihub.37.tgz",
-      "integrity": "sha512-o8/8qlzgeNk3A7hZhhQwmdwyat3qVYlBNbdJ9695xm7u8QzR/u+V6tni9YfGy0FngdnuHQekz/pt+/ds+Tn41A==",
+      "version": "1.0.1-ccdihub.39",
+      "resolved": "https://registry.npmjs.org/@bento-core/facet-filter/-/facet-filter-1.0.1-ccdihub.39.tgz",
+      "integrity": "sha512-0dYGeep7PAKJgzlm5QY/WjqD8IY3Ju/r+Pt7kW9FZmaevcU3yZxx58Pek7wUmfR8gJu92FEq61AGHDcnlACh8g==",
       "requires": {
         "@bento-core/util": "1.0.1-ccdihub.1",
         "lodash": "^4.17.20"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/core": "7.2.2",
     "@bento-core/cart": "1.0.1-ccdihub.9",
     "@bento-core/data-table": "^1.0.0",
-    "@bento-core/facet-filter": "1.0.1-ccdihub.37",
+    "@bento-core/facet-filter": "1.0.1-ccdihub.39",
     "@bento-core/global-search": "1.0.1-ccdihub.5",
     "@bento-core/local-find": "1.0.1-ccdihub.11",
     "@bento-core/query-bar": "1.0.1-ccdihub.20",


### PR DESCRIPTION
Bumped @bento-core/facet-filter dependency from version 1.0.1-ccdihub.37 to 1.0.1-ccdihub.39 in package.json and package-lock.json to use the latest features and fixes.