### PR TITLE
PORTAL-2415: Update cBioPortal links from study detail pages to include study parameters

### DIFF
--- a/src/bento/studiesData.js
+++ b/src/bento/studiesData.js
@@ -36,6 +36,23 @@ const studyDownloadLinks = {
   "phs003519": "https://d2xnga7irezzit.cloudfront.net/metadata_files/phs003519_CCDI_Study_Manifest_v3.1.0.xlsx",
 };
 
+const studycBioPortalLinks = {
+  'phs000463': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000463',
+  'phs000464': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000464',
+  'phs000465': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000465',
+  'phs000466': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000466',
+  'phs000467': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000467',
+  'phs000468': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000468',
+  'phs000470': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000470',
+  'phs000471': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000471',
+  'phs001437': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs001437',
+  'phs002276': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs002276',
+  'phs002517': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs002517',
+  'phs002790': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs002790',
+  'phs002883': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs002883',
+  'phs003432': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs003432'
+};
+
 export async function openDoubleLink(url, fileName) {
   let urlContent = await fetch(url);
   if (urlContent.ok) {
@@ -139,5 +156,6 @@ export {
   table,
   GET_STUDIES_DATA_QUERY,
   GET_NUMBER_OF_STUDIES,
-  studyDownloadLinks
+  studyDownloadLinks,
+  studycBioPortalLinks
 };

--- a/src/pages/studyDetail/overview/overviewView.js
+++ b/src/pages/studyDetail/overview/overviewView.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import exportIcon from '../../../assets/studies/exportIcon.svg';
 import manifestIcon from '../../../assets/studies/manifestIcon.svg';
-import { studyDownloadLinks } from '../../../bento/studiesData';
+import { studyDownloadLinks, studycBioPortalLinks } from '../../../bento/studiesData';
 import TabsView from './tabs/TabsView';
 import ModalView from './modal/ModalView';
 import { styles } from './overviewStyle';
@@ -56,9 +56,9 @@ const OverviewView = ({ data, classes }) => {
                             Download Study Manifest
                             <img className={classes.studyManifestIcon} src={manifestIcon} alt="manifestIcon" />
                         </a>
-                        {data.study_id === 'phs002790' && <>
+                        {studycBioPortalLinks[data.study_id] && <>
                             <br/>
-                            <a href="https://cbioportal.ccdi.cancer.gov/" target="_blank" rel="noopener noreferrer">
+                            <a href={studycBioPortalLinks[data.study_id]} target="_blank" rel="noopener noreferrer">
                                 View in CCDI cBioPortal Data Explorer
                                 <img className={classes.exportIcon} src={exportIcon} alt="exportIcon" />
                             </a>


### PR DESCRIPTION
Introduces a mapping of study IDs to cBioPortal links in studiesData.js and updates overviewView.js to display the relevant cBioPortal link for each study if available. This enhances the study overview page by providing direct access to study data in the CCDI cBioPortal Data Explorer.