### PR TITLE
PORTAL-2532:  CCDI Hub CCDI Hub Cohort Selector: "view all cohorts" popup does not include a button "View in Cohort Analyzer" that will open the cohort analyzer

### DIFF
--- a/src/pages/inventory/cohortModal/components/cohortDetails.js
+++ b/src/pages/inventory/cohortModal/components/cohortDetails.js
@@ -444,7 +444,7 @@ const CohortDetails = (props) => {
                         </div>
                     )}
                 </div>
-                <Button variant="contained" className={classes.viewCohortDetailsButton} onClick={handleViewCohortDetailsClick}>View Cohort Details</Button>
+                <Button variant="contained" className={classes.viewCohortDetailsButton} onClick={handleViewCohortDetailsClick}>View in Cohort Analyzer</Button>
             </div>
             </div>
         </>
@@ -820,7 +820,7 @@ const styles = () => ({
     viewCohortDetailsButton: {
         backgroundColor: '#003F74',
         border: '1.25px solid #73A9C7',
-        width: '137px',
+        width: '157px',
         borderRadius: '5px',
         boxShadow: 'none',
         '&:hover': {

--- a/src/pages/inventory/cohortModal/components/cohortList.js
+++ b/src/pages/inventory/cohortModal/components/cohortList.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { withStyles, Button, Tooltip } from '@material-ui/core';
+import { withStyles, Button } from '@material-ui/core';
+import ToolTip from '@bento-core/tool-tip';
 import TrashCanIconGray from '../../../../assets/icons/Trash_Can_Icon_Gray.svg';
 import TrashCanIconWhite from '../../../../assets/icons/Trash_Can_Icon_White.svg';
 import DuplicateIconWhite from '../../../../assets/icons/Duplicate_Icon_White.svg';
@@ -141,7 +142,7 @@ const CohortList = (props) => {
                                     {state[cohort].cohortId}
                                 </span>
                                 <span className={classes.cohortListItemActions}>
-                                    <Tooltip title="Duplicate cohort" arrow>
+                                    <ToolTip title="Duplicate cohort" placement="top" arrow>
                                         <Button
                                             className={classes.actionButton}
                                             onClick={(e) => {
@@ -155,8 +156,8 @@ const CohortList = (props) => {
                                                 className={classes.whiteDuplicateIcon}
                                             />
                                         </Button>
-                                    </Tooltip>
-                                    <Tooltip title="Delete cohort" arrow>
+                                    </ToolTip>
+                                    <ToolTip title="Delete cohort" placement="top-end" arrow>
                                         <Button
                                             className={classes.actionButton}
                                             onClick={(e) => {
@@ -174,7 +175,7 @@ const CohortList = (props) => {
                                                 className={classes.whiteTrashCan}
                                             />
                                         </Button>
-                                    </Tooltip>
+                                    </ToolTip>
                                 </span>
                             </div>
                         );


### PR DESCRIPTION
This pull request updates the cohort modal components to improve usability and align with design standards. The main changes include updating button text, adjusting button width, and switching from Material-UI's `Tooltip` to a custom `ToolTip` component for cohort actions.

**UI Text and Style Updates:**

* Changed the button label in `cohortDetails.js` from "View Cohort Details" to "View in Cohort Analyzer" for clearer action description.
* Increased the width of the `viewCohortDetailsButton` from 137px to 157px to accommodate the new label.

**Component and Tooltip Improvements:**

* Replaced Material-UI's `Tooltip` with the custom `ToolTip` component from `@bento-core/tool-tip` for cohort action buttons in `cohortList.js`.
* Updated all tooltip usages for "Duplicate cohort" and "Delete cohort" actions to use the new `ToolTip` component, specifying placement and arrow options for improved consistency and positioning. [[1]](diffhunk://#diff-ecc0011695c00221408b7539ea12e506aa54c1d4cc14d502f775fc2f303c7a22L144-R145) [[2]](diffhunk://#diff-ecc0011695c00221408b7539ea12e506aa54c1d4cc14d502f775fc2f303c7a22L158-R160) [[3]](diffhunk://#diff-ecc0011695c00221408b7539ea12e506aa54c1d4cc14d502f775fc2f303c7a22L177-R178)