### PR TITLE
PORTAL-2492 - CCDI Hub: Study Details page: cBioPortal links from study detail pages does not include study parameters

### DIFF
--- a/src/bento/studiesData.js
+++ b/src/bento/studiesData.js
@@ -47,20 +47,22 @@ const studyDownloadLinks = {
 };
 
 const studycBioPortalLinks = {
-  'phs000463': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000463',
-  'phs000464': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000464',
-  'phs000465': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000465',
-  'phs000466': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000466',
-  'phs000467': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000467',
-  'phs000468': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000468',
-  'phs000470': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000470',
-  'phs000471': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs000471',
-  'phs001437': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs001437',
-  'phs002276': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs002276',
-  'phs002517': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs002517',
+  'phs000463': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000464': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000465': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000466': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000467': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000468': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000469': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000470': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000471': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs001437': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs002276': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs002517': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs002790': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs002790',
-  'phs002883': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs002883',
-  'phs003432': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs003432'
+  'phs002883': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs003432': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs003519': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
 };
 
 export async function openDoubleLink(url, fileName) {


### PR DESCRIPTION
Replaces individual study IDs with a unified 'openpedcan_v15' cBioPortal link for multiple studies.