### PR TITLE
PORTAL-2492 - CCDI Hub: Study Details page: cBioPortal links from study detail pages does not include study parameters

### DIFF
--- a/src/bento/studiesData.js
+++ b/src/bento/studiesData.js
@@ -45,20 +45,22 @@ const studyDownloadLinks = {
 };
 
 const studycBioPortalLinks = {
-  'phs000463': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000463',
-  'phs000464': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000464',
-  'phs000465': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000465',
-  'phs000466': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000466',
-  'phs000467': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000467',
-  'phs000468': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000468',
-  'phs000470': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000470',
-  'phs000471': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs000471',
-  'phs001437': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs001437',
-  'phs002276': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs002276',
-  'phs002517': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs002517',
-  'phs002790': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs002790',
-  'phs002883': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs002883',
-  'phs003432': 'https://cbioportal.ccdi.cancer.gov/?studyId=phs003432'
+  'phs000463': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000464': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000465': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000466': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000467': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000468': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000469': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000470': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs000471': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs001437': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs002276': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs002517': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs002790': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs002790',
+  'phs002883': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs003432': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
+  'phs003519': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
 };
 
 


### PR DESCRIPTION
Updated the cBioPortal links for multiple studies to use the new summary URL format with 'openpedcan_v15'.