### PR TITLE
CCDI HUB :Study Details page:Phs000469 should not have the cbioportal link attached to it in study details page

### DIFF
--- a/src/bento/studiesData.js
+++ b/src/bento/studiesData.js
@@ -51,7 +51,6 @@ const studycBioPortalLinks = {
   'phs000466': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs000467': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs000468': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
-  'phs000469': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs000470': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs000471': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs001437': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
@@ -60,9 +59,7 @@ const studycBioPortalLinks = {
   'phs002790': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs002790',
   'phs002883': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs003432': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
-  'phs003519': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
 };
-
 
 export async function openDoubleLink(url, fileName) {
   let urlContent = await fetch(url);


### PR DESCRIPTION
Remove redundant entries 'phs000469' and 'phs003519' from the studycBioPortalLinks map (both pointed to the same openpedcan_v15 URL). Also trim an extra blank line before the export for minor formatting cleanup.