### PR TITLE
PORTAL-2247: All internal linked CCDI hub pages: Repeated Consent Prompt while opening internal link in New Tab

### DIFF
--- a/src/components/OverlayWindow/OverlayWindow.js
+++ b/src/components/OverlayWindow/OverlayWindow.js
@@ -24,11 +24,11 @@ const OverlayWindow = () => {
   const handleClose = () => {
     setOpen(false);
     setOverLayWindow(false);
-    sessionStorage.setItem('overlayLoad', 'true');
+    localStorage.setItem('overlayLoad', 'true');
   };
 
-  useEffect(() => {
-    if (!sessionStorage.length) {
+  useEffect(() => { 
+    if (!localStorage.getItem('overlayLoad')) {
       setOpen(true);
       setOverLayWindow(true);
     }


### PR DESCRIPTION
Store and read the overlay flag from localStorage instead of sessionStorage so the overlay state persists across browser sessions. Replaced sessionStorage.setItem with localStorage.setItem in handleClose, and updated the useEffect check to use localStorage.getItem('overlayLoad') instead of testing sessionStorage.length.