### PR TITLE
PORTAL-2574: Add PMTL link to navbar sublist

### DIFF
--- a/src/bento/globalHeaderData.js
+++ b/src/bento/globalHeaderData.js
@@ -109,6 +109,11 @@ export const navbarSublists = {
     link: 'https://nccrdataplatform.ccdi.cancer.gov/home',
     className: 'navMobileSubItem',
   },
+  {
+    name:'Pediatric Molecular Target List',
+    link: '/PMTL',
+    className: 'navMobileSubItem',
+  },
   // {
   //   name:'Cancer Genomics Cloud',
   //   link: 'https://www.cancergenomicscloud.org',


### PR DESCRIPTION
Add a 'Pediatric Molecular Target List' entry to navbarSublists in src/bento/globalHeaderData.js. The new nav item points to /PMTL and uses the 'navMobileSubItem' class so the PMTL page appears in the mobile sub-navigation.