### PR TITLE
PORTAL-2574: Update PMTL title and header text

### DIFF
--- a/src/bento/globalHeaderData.js
+++ b/src/bento/globalHeaderData.js
@@ -110,7 +110,7 @@ export const navbarSublists = {
     className: 'navMobileSubItem',
   },
   {
-    name:'Pediatric Molecular Target List',
+    name:'Pediatric Molecular Target Lists',
     link: '/PMTL',
     className: 'navMobileSubItem',
   },

--- a/src/pages/resource/PMTLResourcePage/PMTLResourceView.js
+++ b/src/pages/resource/PMTLResourcePage/PMTLResourceView.js
@@ -594,7 +594,7 @@ const PMTLResourceView = ({data}) => {
             </div>
             <div className='resourceTitleContainer'>
                 <div className='resourceTitle'>
-                    <div className='resourceTitleText'>Pediatric, Adolescent, and Young Adult Rare Cancer Study</div>
+                    <div className='resourceTitleText'>Pediatric Molecular Target Lists</div>
                     {/* <div className='goToSiteButton'>
                         <a className='goToSiteText' href="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002790" target="_blank" rel="noopener noreferrer">Request Access (dbGaP)</a>
                     </div> */}


### PR DESCRIPTION
This pull request updates the naming of the Pediatric Molecular Target Lists resource to ensure consistency across the navigation and the resource view page.

Naming consistency updates:

* Changed the navigation label in `src/bento/globalHeaderData.js` from "Pediatric Molecular Target List" to "Pediatric Molecular Target Lists" to match the intended plural form.
* Updated the page title in `src/pages/resource/PMTLResourcePage/PMTLResourceView.js` from "Pediatric, Adolescent, and Young Adult Rare Cancer Study" to "Pediatric Molecular Target Lists" for accuracy and consistency.