### PR TITLE
PORTAL-2574: Pluralize Pediatric Molecular Target List label

### DIFF
--- a/src/bento/globalHeaderData.js
+++ b/src/bento/globalHeaderData.js
@@ -110,7 +110,7 @@ export const navbarSublists = {
     className: 'navMobileSubItem',
   },
   {
-    name:'Pediatric Molecular Target List',
+    name:'Pediatric Molecular Target Lists',
     link: '/pmtl',
     className: 'navMobileSubItem',
   },


### PR DESCRIPTION
Change the navbar sublist entry from 'Pediatric Molecular Target List' to 'Pediatric Molecular Target Lists' in src/bento/globalHeaderData.js to correct the wording and match the intended plural resource at /pmtl.