### PR TITLE
PORTAL-2652 - CCDI HUB: Study Details page: Phs000469 should not have the cbioportal link attached to it in study details page

### DIFF
--- a/src/bento/studiesData.js
+++ b/src/bento/studiesData.js
@@ -54,7 +54,6 @@ const studycBioPortalLinks = {
   'phs000466': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs000467': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs000468': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
-  'phs000469': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs000470': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs000471': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs001437': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
@@ -63,7 +62,6 @@ const studycBioPortalLinks = {
   'phs002790': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=phs002790',
   'phs002883': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
   'phs003432': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
-  'phs003519': 'https://cbioportal.ccdi.cancer.gov/study/summary?id=openpedcan_v15',
 };
 
 const studyClinicalDataLinks = {


### PR DESCRIPTION
Remove phs000469 and phs003519 from the studycBioPortalLinks mapping in src/bento/studiesData.js. These entries pointed to the same OpenPedCan cBioPortal study and were removed as cleanup/duplication/obsolete entries; no other logic was changed.