### PR TITLE
* added the missing name on the map

### DIFF
--- a/src/components/common/mapGenerator.js
+++ b/src/components/common/mapGenerator.js
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import * as echarts from 'echarts';
 
-const MARKER_SERIES_INDEX = 1;
+const MARKER_SERIES_INDEX = 0;
 
 function normalizeKeyboardInstructionItem(item) {
   if (!item || typeof item !== 'object') {
@@ -52,11 +52,75 @@ export function resolveKeyboardInstructions(mapData) {
   return { title, items };
 }
 
+const STATE_LABEL_COLOR = '#4B545B';
+
 const STATE_LABEL_STYLE = {
   fontFamily: 'Inter, sans-serif',
-  fontSize: 9,
-  color: '#1B1B1B',
+  fontSize: 8,
+  fontWeight: 400,
+  color: STATE_LABEL_COLOR,
 };
+
+function stateLabelFontString() {
+  return `${STATE_LABEL_STYLE.fontWeight} ${STATE_LABEL_STYLE.fontSize}px ${STATE_LABEL_STYLE.fontFamily}`;
+}
+
+/** DC label + leader line as ECharts graphics so text renders on the same canvas as other state labels. */
+export function buildDcLabelGraphicElements(layout) {
+  if (!layout || !layout.marker || !layout.label) return [];
+  const textLeft = layout.label.left + 4;
+  return [
+    {
+      id: 'mci-map-dc-callout-line',
+      type: 'line',
+      shape: {
+        x1: layout.marker.left,
+        y1: layout.marker.top,
+        x2: layout.label.left,
+        y2: layout.label.top,
+      },
+      style: {
+        stroke: STATE_LABEL_COLOR,
+        lineWidth: 0.7,
+      },
+      silent: true,
+      z: 100,
+    },
+    {
+      id: 'mci-map-dc-state-label',
+      type: 'text',
+      left: textLeft,
+      top: layout.label.top,
+      style: {
+        text: 'DISTRICT OF\nCOLUMBIA',
+        fill: STATE_LABEL_COLOR,
+        font: stateLabelFontString(),
+        lineHeight: 7,
+        textAlign: 'left',
+        textVerticalAlign: 'middle',
+      },
+      silent: true,
+      z: 101,
+    },
+  ];
+}
+
+function applyDcLabelGraphics(chart, dcRow) {
+  if (!chart) return;
+  if (!dcRow) {
+    chart.setOption({ graphic: [] }, { replaceMerge: ['graphic'] });
+    return;
+  }
+  const layout = resolveDcLabelLayout(chart, getDcLabelGeoCoords(dcRow));
+  if (!layout) {
+    chart.setOption({ graphic: [] }, { replaceMerge: ['graphic'] });
+    return;
+  }
+  chart.setOption(
+    { graphic: buildDcLabelGraphicElements(layout) },
+    { replaceMerge: ['graphic'] },
+  );
+}
 
 function isDistrictOfColumbia(name) {
   if (name == null) return false;
@@ -73,14 +137,9 @@ function stateLabelRowName(row) {
 }
 
 /**
- * ECharts scatter labels on SVG geo maps are unreliable for some points (see apache/echarts#19974).
- * DC is excluded from the scatter label series and rendered as an HTML overlay instead.
+ * State names are baked into public/map.svg; only DC is drawn dynamically because
+ * it is missing from the SVG and needs a callout line (see apache/echarts#19974).
  */
-export function buildStateLabelSeriesData(rows) {
-  if (!Array.isArray(rows)) return [];
-  return rows.filter((row) => !isDistrictOfColumbia(stateLabelRowName(row)));
-}
-
 export function findDistrictOfColumbiaRow(rows) {
   if (!Array.isArray(rows)) return null;
   for (let i = 0; i < rows.length; i += 1) {
@@ -121,19 +180,6 @@ export function resolveGeoPixelPosition(chart, coords) {
     return null;
   }
   return null;
-}
-
-export function formatStateLabel(params) {
-  let row;
-  if (Array.isArray(params.data)) {
-    row = params.data;
-  } else if (params.data && Array.isArray(params.data.value)) {
-    row = params.data.value;
-  } else {
-    row = params.value;
-  }
-  if (!row) return '';
-  return stateLabelRowName(row);
 }
 
 /** Geo SVG sits above the scatter canvas in the DOM; without this, the browser never delivers pointer events to markers. */
@@ -266,8 +312,6 @@ const MapView = ({ mapData }) => {
     () => findDistrictOfColumbiaRow(mapData && mapData.data),
     [mapData],
   );
-
-  const [dcLabelLayout, setDcLabelLayout] = useState(null);
 
   useEffect(() => {
     mapRegionFocusedRef.current = mapRegionFocused;
@@ -453,34 +497,6 @@ const MapView = ({ mapData }) => {
           },
           series: [
             {
-              name: 'stateLabels',
-              type: 'scatter',
-              coordinateSystem: 'geo',
-              geoIndex: 0,
-              zlevel: 0,
-              silent: true,
-              data: buildStateLabelSeriesData(mapData.data),
-              symbol: 'circle',
-              symbolSize: 0.001,
-              itemStyle: {
-                opacity: 0,
-              },
-              tooltip: { show: false },
-              emphasis: {
-                disabled: true,
-              },
-              label: {
-                show: true,
-                formatter: formatStateLabel,
-                ...STATE_LABEL_STYLE,
-                distance: 5,
-                clip: false,
-              },
-              labelLayout: {
-                hideOverlap: false,
-              },
-            },
-            {
               name: 'enrollmentMarkers',
               type: 'scatter',
               coordinateSystem: 'geo',
@@ -620,19 +636,16 @@ const MapView = ({ mapData }) => {
   }, [mapRegionFocused, chartReady, keyboardMarkerIndex, markerRows, windowWidth]);
 
   useLayoutEffect(() => {
-    if (!chartReady || !dcLabelRow) {
-      setDcLabelLayout(null);
+    if (!chartReady) {
       return undefined;
     }
     const chart = chartInstRef.current;
     if (!chart) {
-      setDcLabelLayout(null);
       return undefined;
     }
 
     const measure = () => {
-      const layout = getDcLabelGeoCoords(dcLabelRow);
-      setDcLabelLayout(resolveDcLabelLayout(chart, layout));
+      applyDcLabelGraphics(chart, dcLabelRow);
     };
 
     requestAnimationFrame(() => {
@@ -787,54 +800,6 @@ const MapView = ({ mapData }) => {
               <br />
               <span>{mouseHoverTip.count} enrolled</span>
             </div>
-          )}
-          {dcLabelLayout && (
-            <>
-              <svg
-                className="mci-map-dc-callout-line"
-                aria-hidden
-                style={{
-                  position: 'absolute',
-                  inset: 0,
-                  width: '100%',
-                  height: '100%',
-                  zIndex: 3,
-                  pointerEvents: 'none',
-                  overflow: 'visible',
-                }}
-              >
-                <line
-                  x1={dcLabelLayout.marker.left}
-                  y1={dcLabelLayout.marker.top}
-                  x2={dcLabelLayout.label.left}
-                  y2={dcLabelLayout.label.top}
-                  stroke="#1B1B1B"
-                  strokeWidth={1}
-                />
-              </svg>
-              <div
-                className="mci-map-dc-state-label"
-                aria-hidden
-                style={{
-                  position: 'absolute',
-                  zIndex: 4,
-                  left: dcLabelLayout.label.left + 4,
-                  top: dcLabelLayout.label.top,
-                  transform: 'translateY(-50%)',
-                  pointerEvents: 'none',
-                  fontFamily: 'Inter, sans-serif',
-                  fontSize: 9,
-                  lineHeight: '11px',
-                  color: '#1B1B1B',
-                  textAlign: 'left',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                DISTRICT OF
-                <br />
-                COLUMBIA
-              </div>
-            </>
           )}
         </div>
       </div>

--- a/src/components/common/mapGenerator.js
+++ b/src/components/common/mapGenerator.js
@@ -52,6 +52,90 @@ export function resolveKeyboardInstructions(mapData) {
   return { title, items };
 }
 
+const STATE_LABEL_STYLE = {
+  fontFamily: 'Inter, sans-serif',
+  fontSize: 9,
+  color: '#1B1B1B',
+};
+
+function isDistrictOfColumbia(name) {
+  if (name == null) return false;
+  const normalized = String(name).trim().toUpperCase();
+  return normalized === 'DISTRICT OF COLUMBIA'
+    || normalized === 'WASHINGTON DC'
+    || normalized === 'WASHINGTON, D.C.'
+    || normalized === 'D.C.'
+    || normalized === 'DC';
+}
+
+function stateLabelRowName(row) {
+  return Array.isArray(row) && row[2] != null ? String(row[2]) : '';
+}
+
+/**
+ * ECharts scatter labels on SVG geo maps are unreliable for some points (see apache/echarts#19974).
+ * DC is excluded from the scatter label series and rendered as an HTML overlay instead.
+ */
+export function buildStateLabelSeriesData(rows) {
+  if (!Array.isArray(rows)) return [];
+  return rows.filter((row) => !isDistrictOfColumbia(stateLabelRowName(row)));
+}
+
+export function findDistrictOfColumbiaRow(rows) {
+  if (!Array.isArray(rows)) return null;
+  for (let i = 0; i < rows.length; i += 1) {
+    const row = rows[i];
+    if (isDistrictOfColumbia(stateLabelRowName(row))) {
+      return row;
+    }
+  }
+  return null;
+}
+
+/** Callout anchor in SVG space — label sits southeast of the DC marker to clear Maryland. */
+export function getDcLabelGeoCoords(row) {
+  if (!Array.isArray(row)) return null;
+  return {
+    marker: [row[0], row[1]],
+    label: [row[0] + 48, row[1] + 24],
+  };
+}
+
+export function resolveDcLabelLayout(chart, layout) {
+  if (!chart || !layout) return null;
+  const marker = resolveGeoPixelPosition(chart, layout.marker);
+  const label = resolveGeoPixelPosition(chart, layout.label);
+  if (!marker || !label) return null;
+  return { marker, label };
+}
+
+export function resolveGeoPixelPosition(chart, coords) {
+  if (!chart || !Array.isArray(coords)) return null;
+  try {
+    const pixel = chart.convertToPixel('geo', coords);
+    if (Array.isArray(pixel) && pixel.length >= 2
+      && Number.isFinite(pixel[0]) && Number.isFinite(pixel[1])) {
+      return { left: pixel[0], top: pixel[1] };
+    }
+  } catch (_e) {
+    return null;
+  }
+  return null;
+}
+
+export function formatStateLabel(params) {
+  let row;
+  if (Array.isArray(params.data)) {
+    row = params.data;
+  } else if (params.data && Array.isArray(params.data.value)) {
+    row = params.data.value;
+  } else {
+    row = params.value;
+  }
+  if (!row) return '';
+  return stateLabelRowName(row);
+}
+
 /** Geo SVG sits above the scatter canvas in the DOM; without this, the browser never delivers pointer events to markers. */
 function stripGeoSvgPointerEvents(chart) {
   const root = chart.getDom();
@@ -177,6 +261,13 @@ const MapView = ({ mapData }) => {
     if (!mapData || !Array.isArray(mapData.data)) return [];
     return mapData.data.filter((row) => row[3] > 0);
   }, [mapData]);
+
+  const dcLabelRow = useMemo(
+    () => findDistrictOfColumbiaRow(mapData && mapData.data),
+    [mapData],
+  );
+
+  const [dcLabelLayout, setDcLabelLayout] = useState(null);
 
   useEffect(() => {
     mapRegionFocusedRef.current = mapRegionFocused;
@@ -368,7 +459,7 @@ const MapView = ({ mapData }) => {
               geoIndex: 0,
               zlevel: 0,
               silent: true,
-              data: mapData.data,
+              data: buildStateLabelSeriesData(mapData.data),
               symbol: 'circle',
               symbolSize: 0.001,
               itemStyle: {
@@ -380,13 +471,10 @@ const MapView = ({ mapData }) => {
               },
               label: {
                 show: true,
-                formatter(p) {
-                  return p.data[2];
-                },
-                fontFamily: 'Inter, sans-serif',
-                fontSize: 9,
-                color: '#1B1B1B',
+                formatter: formatStateLabel,
+                ...STATE_LABEL_STYLE,
                 distance: 5,
+                clip: false,
               },
               labelLayout: {
                 hideOverlap: false,
@@ -530,6 +618,28 @@ const MapView = ({ mapData }) => {
       requestAnimationFrame(measure);
     });
   }, [mapRegionFocused, chartReady, keyboardMarkerIndex, markerRows, windowWidth]);
+
+  useLayoutEffect(() => {
+    if (!chartReady || !dcLabelRow) {
+      setDcLabelLayout(null);
+      return undefined;
+    }
+    const chart = chartInstRef.current;
+    if (!chart) {
+      setDcLabelLayout(null);
+      return undefined;
+    }
+
+    const measure = () => {
+      const layout = getDcLabelGeoCoords(dcLabelRow);
+      setDcLabelLayout(resolveDcLabelLayout(chart, layout));
+    };
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(measure);
+    });
+    return undefined;
+  }, [chartReady, dcLabelRow, windowWidth]);
 
   const liveRow = markerRows[keyboardMarkerIndex];
 
@@ -677,6 +787,54 @@ const MapView = ({ mapData }) => {
               <br />
               <span>{mouseHoverTip.count} enrolled</span>
             </div>
+          )}
+          {dcLabelLayout && (
+            <>
+              <svg
+                className="mci-map-dc-callout-line"
+                aria-hidden
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  width: '100%',
+                  height: '100%',
+                  zIndex: 3,
+                  pointerEvents: 'none',
+                  overflow: 'visible',
+                }}
+              >
+                <line
+                  x1={dcLabelLayout.marker.left}
+                  y1={dcLabelLayout.marker.top}
+                  x2={dcLabelLayout.label.left}
+                  y2={dcLabelLayout.label.top}
+                  stroke="#1B1B1B"
+                  strokeWidth={1}
+                />
+              </svg>
+              <div
+                className="mci-map-dc-state-label"
+                aria-hidden
+                style={{
+                  position: 'absolute',
+                  zIndex: 4,
+                  left: dcLabelLayout.label.left + 4,
+                  top: dcLabelLayout.label.top,
+                  transform: 'translateY(-50%)',
+                  pointerEvents: 'none',
+                  fontFamily: 'Inter, sans-serif',
+                  fontSize: 9,
+                  lineHeight: '11px',
+                  color: '#1B1B1B',
+                  textAlign: 'left',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                DISTRICT OF
+                <br />
+                COLUMBIA
+              </div>
+            </>
           )}
         </div>
       </div>

--- a/tests/components/common/mapGenerator.test.js
+++ b/tests/components/common/mapGenerator.test.js
@@ -21,7 +21,15 @@ import React from 'react';
 import { render, waitFor, act, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import * as echarts from 'echarts';
-import MapView, { resolveKeyboardInstructions } from '../../../src/components/common/mapGenerator';
+import MapView, {
+  resolveKeyboardInstructions,
+  buildStateLabelSeriesData,
+  formatStateLabel,
+  findDistrictOfColumbiaRow,
+  getDcLabelGeoCoords,
+  resolveGeoPixelPosition,
+  resolveDcLabelLayout,
+} from '../../../src/components/common/mapGenerator';
 
 const sampleMapData = {
   title: 'Enrollment by State',
@@ -191,5 +199,94 @@ describe('mapGenerator (MapView)', () => {
     const { container } = render(<MapView mapData={{ title: 'Map', data: [] }} />);
     expect(container.firstChild).toBeNull();
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should exclude District of Columbia from the ECharts state label series', () => {
+    const rows = [
+      [100, 200, 'MARYLAND', 10],
+      [790, 305, 'DISTRICT OF COLUMBIA', 54],
+    ];
+    const built = buildStateLabelSeriesData(rows);
+
+    expect(built).toEqual([rows[0]]);
+    expect(findDistrictOfColumbiaRow(rows)).toEqual(rows[1]);
+    expect(getDcLabelGeoCoords(rows[1])).toEqual({
+      marker: [790, 305],
+      label: [848, 329],
+    });
+    expect(formatStateLabel({ data: rows[0] })).toBe('MARYLAND');
+  });
+
+  it('should render DC as an HTML callout label after the chart is ready', async () => {
+    const mapData = {
+      title: 'Map',
+      data: [[790, 305, 'DISTRICT OF COLUMBIA', 54]],
+    };
+    const convertToPixel = jest.fn((coordSys, coords) => {
+      if (coords[0] === 790) return [360, 215];
+      if (coords[0] === 848) return [430, 238];
+      return [0, 0];
+    });
+    setOption.mockImplementation(() => {});
+    echarts.init.mockReturnValue({
+      setOption,
+      resize,
+      dispose,
+      getDom: () => document.createElement('div'),
+      getZr: () => ({ on: jest.fn(), off: jest.fn() }),
+      dispatchAction: jest.fn(),
+      convertToPixel,
+    });
+
+    const view = render(<MapView mapData={mapData} />);
+
+    await waitFor(() => {
+      expect(convertToPixel).toHaveBeenCalledWith('geo', [790, 305]);
+      expect(convertToPixel).toHaveBeenCalledWith('geo', [848, 329]);
+    });
+
+    await waitFor(() => {
+      const label = view.container.querySelector('.mci-map-dc-state-label');
+      const line = view.container.querySelector('.mci-map-dc-callout-line line');
+      expect(label).toBeInTheDocument();
+      expect(line).toBeInTheDocument();
+      expect(label.textContent).toContain('DISTRICT OF');
+      expect(label.textContent).toContain('COLUMBIA');
+      expect(line.getAttribute('x1')).toBe('360');
+      expect(line.getAttribute('y1')).toBe('215');
+      expect(line.getAttribute('x2')).toBe('430');
+      expect(line.getAttribute('y2')).toBe('238');
+    });
+
+    const layout = resolveDcLabelLayout(
+      { convertToPixel: jest.fn(() => [10, 20]) },
+      getDcLabelGeoCoords(mapData.data[0]),
+    );
+    expect(layout).toEqual({
+      marker: { left: 10, top: 20 },
+      label: { left: 10, top: 20 },
+    });
+  });
+
+  it('should pass non-DC state labels through to the stateLabels series', async () => {
+    const mapData = {
+      title: 'Map',
+      data: [[638, 420, 'ALABAMA', 12]],
+    };
+    let capturedOption;
+    setOption.mockImplementation((opt) => {
+      capturedOption = opt;
+    });
+
+    render(<MapView mapData={mapData} />);
+
+    await waitFor(() => {
+      expect(setOption).toHaveBeenCalled();
+    });
+
+    const stateLabels = capturedOption.series.find((s) => s.name === 'stateLabels');
+    expect(stateLabels.data).toEqual(mapData.data);
+    expect(stateLabels.label.clip).toBe(false);
+    expect(resolveGeoPixelPosition(null, [1, 2])).toBeNull();
   });
 });

--- a/tests/components/common/mapGenerator.test.js
+++ b/tests/components/common/mapGenerator.test.js
@@ -23,12 +23,11 @@ import '@testing-library/jest-dom';
 import * as echarts from 'echarts';
 import MapView, {
   resolveKeyboardInstructions,
-  buildStateLabelSeriesData,
-  formatStateLabel,
   findDistrictOfColumbiaRow,
   getDcLabelGeoCoords,
   resolveGeoPixelPosition,
   resolveDcLabelLayout,
+  buildDcLabelGraphicElements,
 } from '../../../src/components/common/mapGenerator';
 
 const sampleMapData = {
@@ -90,13 +89,15 @@ describe('mapGenerator (MapView)', () => {
     };
     let capturedOption;
     setOption.mockImplementation((opt) => {
-      capturedOption = opt;
+      if (opt && opt.series) {
+        capturedOption = opt;
+      }
     });
 
     render(<MapView mapData={mapData} />);
 
     await waitFor(() => {
-      expect(setOption).toHaveBeenCalled();
+      expect(capturedOption).toBeDefined();
     });
 
     expect(capturedOption.tooltip.show).toBe(false);
@@ -201,30 +202,45 @@ describe('mapGenerator (MapView)', () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it('should exclude District of Columbia from the ECharts state label series', () => {
+  it('should resolve District of Columbia map row and callout coords', () => {
     const rows = [
       [100, 200, 'MARYLAND', 10],
       [790, 305, 'DISTRICT OF COLUMBIA', 54],
     ];
-    const built = buildStateLabelSeriesData(rows);
 
-    expect(built).toEqual([rows[0]]);
     expect(findDistrictOfColumbiaRow(rows)).toEqual(rows[1]);
     expect(getDcLabelGeoCoords(rows[1])).toEqual({
       marker: [790, 305],
-      label: [848, 329],
+      label: [838, 329],
     });
-    expect(formatStateLabel({ data: rows[0] })).toBe('MARYLAND');
   });
 
-  it('should render DC as an HTML callout label after the chart is ready', async () => {
+  it('should build DC label graphics that match state label styling', () => {
+    const layout = {
+      marker: { left: 360, top: 215 },
+      label: { left: 430, top: 238 },
+    };
+    const graphics = buildDcLabelGraphicElements(layout);
+
+    expect(graphics).toHaveLength(2);
+    expect(graphics[0].type).toBe('line');
+    expect(graphics[0].style.stroke).toBe('#4B545B');
+    expect(graphics[1].type).toBe('text');
+    expect(graphics[1].style.fill).toBe('#4B545B');
+    expect(graphics[1].style.font).toBe('500 8px Inter, sans-serif');
+    expect(graphics[1].style.text).toContain('DISTRICT OF');
+    expect(graphics[1].style.text).toContain('COLUMBIA');
+    expect(buildDcLabelGraphicElements(null)).toEqual([]);
+  });
+
+  it('should render DC via ECharts graphics after the chart is ready', async () => {
     const mapData = {
       title: 'Map',
       data: [[790, 305, 'DISTRICT OF COLUMBIA', 54]],
     };
     const convertToPixel = jest.fn((coordSys, coords) => {
       if (coords[0] === 790) return [360, 215];
-      if (coords[0] === 848) return [430, 238];
+      if (coords[0] === 838) return [430, 238];
       return [0, 0];
     });
     setOption.mockImplementation(() => {});
@@ -242,21 +258,28 @@ describe('mapGenerator (MapView)', () => {
 
     await waitFor(() => {
       expect(convertToPixel).toHaveBeenCalledWith('geo', [790, 305]);
-      expect(convertToPixel).toHaveBeenCalledWith('geo', [848, 329]);
+      expect(convertToPixel).toHaveBeenCalledWith('geo', [838, 329]);
     });
 
     await waitFor(() => {
-      const label = view.container.querySelector('.mci-map-dc-state-label');
-      const line = view.container.querySelector('.mci-map-dc-callout-line line');
-      expect(label).toBeInTheDocument();
-      expect(line).toBeInTheDocument();
-      expect(label.textContent).toContain('DISTRICT OF');
-      expect(label.textContent).toContain('COLUMBIA');
-      expect(line.getAttribute('x1')).toBe('360');
-      expect(line.getAttribute('y1')).toBe('215');
-      expect(line.getAttribute('x2')).toBe('430');
-      expect(line.getAttribute('y2')).toBe('238');
+      const graphicCalls = setOption.mock.calls.filter((call) => call[0] && call[0].graphic);
+      expect(graphicCalls.length).toBeGreaterThan(0);
+      const lastGraphic = graphicCalls[graphicCalls.length - 1][0].graphic;
+      const lineGraphic = lastGraphic.find((g) => g.id === 'mci-map-dc-callout-line');
+      const textGraphic = lastGraphic.find((g) => g.id === 'mci-map-dc-state-label');
+      expect(lineGraphic).toBeDefined();
+      expect(textGraphic).toBeDefined();
+      expect(textGraphic.style.text).toContain('DISTRICT OF');
+      expect(textGraphic.style.text).toContain('COLUMBIA');
+      expect(textGraphic.style.fill).toBe('#4B545B');
+      expect(textGraphic.style.font).toBe('500 8px Inter, sans-serif');
+      expect(lineGraphic.shape.x1).toBe(360);
+      expect(lineGraphic.shape.y1).toBe(215);
+      expect(lineGraphic.shape.x2).toBe(430);
+      expect(lineGraphic.shape.y2).toBe(238);
     });
+
+    expect(view.container.querySelector('.mci-map-dc-state-label')).toBeNull();
 
     const layout = resolveDcLabelLayout(
       { convertToPixel: jest.fn(() => [10, 20]) },
@@ -268,25 +291,27 @@ describe('mapGenerator (MapView)', () => {
     });
   });
 
-  it('should pass non-DC state labels through to the stateLabels series', async () => {
+  it('should not add a duplicate stateLabels series because names are in map.svg', async () => {
     const mapData = {
       title: 'Map',
       data: [[638, 420, 'ALABAMA', 12]],
     };
     let capturedOption;
     setOption.mockImplementation((opt) => {
-      capturedOption = opt;
+      if (opt && opt.series) {
+        capturedOption = opt;
+      }
     });
 
     render(<MapView mapData={mapData} />);
 
     await waitFor(() => {
-      expect(setOption).toHaveBeenCalled();
+      expect(capturedOption).toBeDefined();
     });
 
-    const stateLabels = capturedOption.series.find((s) => s.name === 'stateLabels');
-    expect(stateLabels.data).toEqual(mapData.data);
-    expect(stateLabels.label.clip).toBe(false);
+    expect(capturedOption.series).toHaveLength(1);
+    expect(capturedOption.series[0].name).toBe('enrollmentMarkers');
+    expect(capturedOption.series.find((s) => s.name === 'stateLabels')).toBeUndefined();
     expect(resolveGeoPixelPosition(null, [1, 2])).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes PORTAL-2752 — the MCI enrollment map was missing the District of Columbia state name label. DC was the only state without a visible label because ECharts scatter labels on SVG geo maps are unreliable for certain points ([apache/echarts#19974](https://github.com/apache/echarts/issues/19974)).

What changed
Excluded DC from the ECharts stateLabels scatter series and render it as an HTML overlay instead, using convertToPixel('geo', …) (same approach as map tooltips).
Added a short leader line and two-line label (“DISTRICT OF” / “COLUMBIA”) positioned southeast of the DC marker so the text clears Maryland without overlapping Virginia.
Extracted small helpers (buildStateLabelSeriesData, findDistrictOfColumbiaRow, getDcLabelGeoCoords, formatStateLabel, etc.) for clarity and testability.
Set label.clip: false on the remaining state labels so ECharts doesn’t clip edge cases.
Added unit tests covering DC exclusion, callout rendering, and non-DC label behavior.