### PR TITLE
remvoe MTP from landing page

### DIFF
--- a/src/bento/globalHeaderData.js
+++ b/src/bento/globalHeaderData.js
@@ -80,11 +80,6 @@ export const navbarSublists = {
     className: 'navMobileSubItem',
   },
   {
-    name: 'Molecular Targets Platform',
-    link: 'https://moleculartargets.ccdi.cancer.gov',
-    className: 'navMobileSubItem',
-  },
-  {
     name:'National Childhood Cancer Registry Explorer',
     link: 'https://nccrexplorer.ccdi.cancer.gov',
     className: 'navMobileSubItem',

--- a/src/bento/landingPageData.js
+++ b/src/bento/landingPageData.js
@@ -4,7 +4,6 @@ import aboutImg from '../assets/landing/About_1.png';
 import wheel1 from '../assets/landing/ccdc_carousel.svg';
 import wheel2 from '../assets/landing/civic_carousel.svg';
 import wheel3 from '../assets/landing/mci_carousel.svg';
-import wheel4 from '../assets/landing/mtp_carousel.svg';
 import wheel5 from '../assets/landing/nccr_carousel.svg';
 import wheel6 from '../assets/landing/cgc_carousel.svg';
 import wheel7 from '../assets/landing/dbgap_carousel.svg';
@@ -19,7 +18,6 @@ import c3dcLogo from '../assets/landing/c3dc_logo.svg';
 import ccdcMobile from '../assets/landing/ccdc_mobile.png';
 import civicMobile from '../assets/landing/civic_mobile.png';
 import mciMobile from '../assets/landing/mci_mobile.png';
-import mtpMobile from '../assets/landing/mtp_mobile.png';
 import nccrMobile from '../assets/landing/nccr_mobile.png';
 import cgcMobile from '../assets/landing/cgc_mobile.png';
 import dbgapMobile from '../assets/landing/dbgap_mobile.png';
@@ -33,7 +31,6 @@ import cBioPortalMobile from '../assets/landing/cBioPortal_mobile.png';
 import ccdcLogo from '../assets/landing/ccdc_logo.svg';
 import civicLogo from '../assets/landing/civic_logo.svg';
 import mciLogo from '../assets/landing/mci_logo.svg';
-import mtpLogo from '../assets/landing/mtp_logo.svg';
 import nccrLogo from '../assets/landing/nccr_logo.svg';
 import cgcLogo from '../assets/landing/cgc_logo.svg';
 import dbgapLogo from '../assets/landing/dbgap_logo.svg';
@@ -73,12 +70,6 @@ export const statsData = [
     title: 'Participants with Available Genomic and Clinical Data',
     detail: 'Molecular Characterization Initiative',
     link: '/MCI',
-  },
-  {
-    num: 58867,
-    title: 'Potential Pediatric Molecular Targets',
-    detail: 'Molecular Targets Platform',
-    link: 'https://moleculartargets.ccdi.cancer.gov',
   },
   {
     num: 1700440,
@@ -123,14 +114,6 @@ export const resourcesAppliationsListData = [
     link: '/MCI',
     img: mciLogo,
     noLink: true,
-  },
-  {
-    id: 'mtp',
-    title: 'Molecular Targets Platform',
-    subtitle: 'MTP',
-    content: 'An instance of the Open Targets Platform with a focus on childhood cancer data that allows users to browse and identify associations between molecular targets, diseases, and drugs.',
-    link: 'https://moleculartargets.ccdi.cancer.gov',
-    img: mtpLogo,
   },
   {
     id: 'nccrexplorer',
@@ -254,12 +237,6 @@ export const carouselList = [
     mobile: mciMobile,
     content: 'Molecular Characterization Initiative',
     link: '/MCI',
-  },
-  {
-    img: wheel4,
-    mobile: mtpMobile,
-    content: 'Molecular Targets Platform',
-    link: 'https://moleculartargets.ccdi.cancer.gov',
   },
   {
     img: wheel5,

--- a/src/bento/newsData.js
+++ b/src/bento/newsData.js
@@ -336,8 +336,11 @@ export const newsList = [
         type: 'CCDI Application Updates',
         img: 'updateImgNewApplicationRelease',
     },
+    {
+        id: 'molecularcharacterization_07202023',
+        title: 'Molecular Characterization and Clinical Data from Multiple Organizations Released',
         date: 'JULY 20, 2023',
-        slug: 'Pediatric brain tumor data from several organizations are available pre-publication and without embargo. ',
+        slug: 'Pediatric brain tumor data from several organizations are available pre-publication and without embargo. ',
         highlight: '<p>CCDI has facilitated the release of data from children and young adults diagnosed with pediatric brain tumors and other solid and hematologic malignancies. The data was collected from the Children’s Brain Tumor Network, the Pacific Pediatric Neuro-Oncology Consortium, and the Children’s Hospital of Philadelphia Division for Genomic Diagnostics. They include tumor and germline WGS, RNA-Seq, Clinical Panel Sequencing, and other omics and molecular data. <a href="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002517.v1.p1" rel="noreferrer noopener" target="_blank">Access these data through dbGaP</a>.</p>',
         fullText: '',
         type: 'News',

--- a/src/bento/newsData.js
+++ b/src/bento/newsData.js
@@ -2,8 +2,6 @@ import updateImgCCDC from '../assets/landing/Updates_CCDC.png';
 import updateImgNewApplicationRelease from '../assets/news/News_New_Application_Release.png';
 import updateImgMCI from '../assets/landing/Updates_Molecular.png';
 import updateImgSymposium from '../assets/landing/Updates_Symposium.png';
-import updateImgMTP from '../assets/news/News_MTP.png';
-import updateImgMTP2 from '../assets/news/News_MTP_2.png';
 import updateImgMCI2 from '../assets/news/News_Molecular_Characterization.png';
 import updateImgMiscNews from '../assets/news/News_Misc_News.png';
 import updateImgEHR from '../assets/news/News_EHR.png';
@@ -16,8 +14,6 @@ export const altList = {
     updateImgNewApplicationRelease: 'A laptop screen showing a major new release of a resource, featuring a healthcare website with a child and a doctor interacting, set against a desk with stationary items',
     updateImgMCI: 'Illustration of a person connected to a computer screen displaying a DNA sequence analysis, symbolizing the relationship between human genetics and data analysis.',
     updateImgSymposium: 'Simple icon of two human figures raising their arms together on a blue gradient background.',
-    updateImgMTP: 'A medical professional using a tablet with digital interface graphics and abstract data connections, representing advanced healthcare technology.',
-    updateImgMTP2: 'A laptop displaying a molecular targets platform with large arrows pointing upward, symbolizing growth and progress in the field.',
     updateImgMCI2: 'updateImgMCI2',
     updateImgMiscNews: 'Magnifying glass focusing on a network of people icons, representing detailed analysis or review',
     updateImgEHR: 'updateImgEHR',
@@ -31,8 +27,6 @@ export const srcList = {
     updateImgNewApplicationRelease: updateImgNewApplicationRelease,
     updateImgMCI: updateImgMCI,
     updateImgSymposium: updateImgSymposium,
-    updateImgMTP: updateImgMTP,
-    updateImgMTP2: updateImgMTP2,
     updateImgMCI2: updateImgMCI2,
     updateImgMiscNews: updateImgMiscNews,
     updateImgEHR: updateImgEHR,
@@ -342,19 +336,6 @@ export const newsList = [
         type: 'CCDI Application Updates',
         img: 'updateImgNewApplicationRelease',
     },
-    {
-        id: 'mtp_07212023',
-        title: 'Molecular Targets Platform (MTP) release allows interactive data visualizations',
-        date: 'JULY 21, 2023',
-        slug: 'New interactive plot displays and updates to the About page are part of the MTP 2.1 release.',
-        highlight: '<p>The Molecular Targets Platform (MTP) is now live with interactive visualizations of data via the <a href="https://moleculartargets.ccdi.cancer.gov/pediatric-cancer-data-navigation" target="_blank" rel="noopener noreferrer">Pediatric Data Navigation page</a>. There is also improved plot generation for the OpenPedCan Gene Expression and Differential Expression widgets, along with updated descriptions in the “Pediatric Cancer Data Visualizations” section on the <a href="https://moleculartargets.ccdi.cancer.gov/about" target="_blank" rel="noopener noreferrer">About page</a> regarding the chart types added in the previous MTP release.</p>',
-        fullText: '',
-        type: 'CCDI Application Updates',
-        img: 'updateImgMTP2',
-    },
-    {
-        id: 'molecularcharacterization_07202023',
-        title: 'Molecular Characterization and Clinical Data from Multiple Organizations Released',
         date: 'JULY 20, 2023',
         slug: 'Pediatric brain tumor data from several organizations are available pre-publication and without embargo. ',
         highlight: '<p>CCDI has facilitated the release of data from children and young adults diagnosed with pediatric brain tumors and other solid and hematologic malignancies. The data was collected from the Children’s Brain Tumor Network, the Pacific Pediatric Neuro-Oncology Consortium, and the Children’s Hospital of Philadelphia Division for Genomic Diagnostics. They include tumor and germline WGS, RNA-Seq, Clinical Panel Sequencing, and other omics and molecular data. <a href="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002517.v1.p1" rel="noreferrer noopener" target="_blank">Access these data through dbGaP</a>.</p>',
@@ -381,16 +362,6 @@ export const newsList = [
         fullText: '',
         type: 'CCDI Application Updates',
         img: 'updateImgCCDC',
-    },
-    {
-        id: 'mtp_06022023',
-        title: 'Molecular Targets Platform releases data updates and enhanced features',
-        date: 'JUNE 2, 2023',
-        slug: 'The latest update to the Molecular Targets Platform includes new data and enhanced features. Learn about the recent release.',
-        highlight: '<p>The <a href="https://moleculartargets.ccdi.cancer.gov/" target="_blank" rel="noopener noreferrer">Molecular Targets Platform</a> (MTP) expanded with new data and enhanced features. Researchers will find new and updated data from the Pediatric Brain Tumor Atlas and TARGET cohorts, including sequencing and methylation data. Improved features include enhanced gene expression graphs for childhood cancer data and a new widget to capture methylation data. Finally, the latest coding updates ensure that the data can be easily viewed and queried. <a href="https://moleculartargets.ccdi.cancer.gov/about" target="_blank" rel="noopener noreferrer">Learn more about how the MTP is helping advance childhood cancer research</a>.</p>',
-        fullText: '',
-        type: 'CCDI Application Updates',
-        img: 'updateImgMTP',
     },
     {
         id: 'ccdc_05172023',

--- a/src/components/OverlayWindow/OverlayWindow.js
+++ b/src/components/OverlayWindow/OverlayWindow.js
@@ -15,17 +15,19 @@ import {
 import FiberManualRecord from '@material-ui/icons/FiberManualRecord';
 import * as text from './OverlayText.json';
 import DialogThemeProvider from './OverlayThemeConfig';
+import { setOverLayWindow } from '../../pages/globalSearch/store/sitesearchReducer';
 
 const OverlayWindow = () => {
   const [open, setOpen] = useState(false);
 
   const handleClose = () => {
     setOpen(false);
-    sessionStorage.setItem('overlayLoad', 'true');
+    localStorage.setItem('overlayLoad', 'true');
+    setOverLayWindow(false);
   };
 
   useEffect(() => {
-    if (sessionStorage.getItem('overlayLoad') !== 'true') {
+    if (localStorage.getItem('overlayLoad') !== 'true') {
       setOpen(true);
     }
   }, []);

--- a/src/components/common/mapGenerator.js
+++ b/src/components/common/mapGenerator.js
@@ -57,7 +57,7 @@ const STATE_LABEL_COLOR = '#4B545B';
 const STATE_LABEL_STYLE = {
   fontFamily: 'Inter, sans-serif',
   fontSize: 8,
-  fontWeight: 400,
+  fontWeight: 500,
   color: STATE_LABEL_COLOR,
 };
 

--- a/tests/fixtures/landing/landingViewProps.js
+++ b/tests/fixtures/landing/landingViewProps.js
@@ -17,12 +17,6 @@ export const defaultLandingStatsData = [
     link: '/MCI',
   },
   {
-    num: 58867,
-    title: 'Potential Pediatric Molecular Targets',
-    detail: 'Molecular Targets Platform',
-    link: 'https://moleculartargets.ccdi.cancer.gov',
-  },
-  {
     num: 1700440,
     title: 'Reported Cases Under Age 40<br>(1995-2020)',
     detail: 'National Childhood Cancer Registry Explorer',

--- a/tests/pages/landing/landingView.test.js
+++ b/tests/pages/landing/landingView.test.js
@@ -108,13 +108,12 @@ describe('LandingView', () => {
       renderLandingView();
       const statsSection = screen.getByTestId('landing-stats-section');
       const statLinks = within(statsSection).getAllByRole('link', { name: /Childhood Cancer Data Catalog|Molecular Characterization Initiative|National Childhood Cancer Registry Explorer/i });
-      expect(statLinks.length).toBe(4);
+      expect(statLinks.length).toBe(3);
     });
 
     it('should format stat numbers with en-US locale', () => {
       renderLandingView();
       expect(screen.getByText('1,700,440')).toBeInTheDocument();
-      expect(screen.getByText('58,867')).toBeInTheDocument();
     });
 
     it('should show asterisk for Participants stat', () => {

--- a/tests/pages/landing/landingView.test.js
+++ b/tests/pages/landing/landingView.test.js
@@ -107,7 +107,7 @@ describe('LandingView', () => {
     it('should render one stat item per statsData entry', () => {
       renderLandingView();
       const statsSection = screen.getByTestId('landing-stats-section');
-      const statLinks = within(statsSection).getAllByRole('link', { name: /Childhood Cancer Data Catalog|Molecular Characterization Initiative|Molecular Targets Platform|National Childhood Cancer Registry Explorer/i });
+      const statLinks = within(statsSection).getAllByRole('link', { name: /Childhood Cancer Data Catalog|Molecular Characterization Initiative|National Childhood Cancer Registry Explorer/i });
       expect(statLinks.length).toBe(4);
     });
 


### PR DESCRIPTION
This pull request removes all references to the Molecular Targets Platform (MTP) from the navigation menus, landing page, news section, and associated assets. The main goal is to eliminate MTP as a featured resource across the application, including UI elements, data, and tests.

The most important changes are:

**Landing Page and Navigation Updates:**
* Removed MTP from the navigation sublists in `navbarSublists` in `globalHeaderData.js` and from all landing page UI elements and data, including stats, carousel items, and resource/application lists in `landingPageData.js`. [[1]](diffhunk://#diff-0bbb981664592d771549f5500379ffc605c55a30da9c67cc596e9bb214cdc59fL82-L86) [[2]](diffhunk://#diff-6e1d6ed5c46317ed3cf816df48287dd747d985e8376513cd198aaa2fe91d9ffeL7) [[3]](diffhunk://#diff-6e1d6ed5c46317ed3cf816df48287dd747d985e8376513cd198aaa2fe91d9ffeL22) [[4]](diffhunk://#diff-6e1d6ed5c46317ed3cf816df48287dd747d985e8376513cd198aaa2fe91d9ffeL36) [[5]](diffhunk://#diff-6e1d6ed5c46317ed3cf816df48287dd747d985e8376513cd198aaa2fe91d9ffeL77-L82) [[6]](diffhunk://#diff-6e1d6ed5c46317ed3cf816df48287dd747d985e8376513cd198aaa2fe91d9ffeL127-L134) [[7]](diffhunk://#diff-6e1d6ed5c46317ed3cf816df48287dd747d985e8376513cd198aaa2fe91d9ffeL258-L263)

**News Section Cleanup:**
* Removed all news items, assets, and image references related to MTP from `newsData.js`, including the news list, image imports, alt text, and source mappings. [[1]](diffhunk://#diff-c0e9014b158d93a6e2949908b7d7b7636d14bfdbd7c49157fe1ff07cf18622caL5-L6) [[2]](diffhunk://#diff-c0e9014b158d93a6e2949908b7d7b7636d14bfdbd7c49157fe1ff07cf18622caL19-L20) [[3]](diffhunk://#diff-c0e9014b158d93a6e2949908b7d7b7636d14bfdbd7c49157fe1ff07cf18622caL34-L35) [[4]](diffhunk://#diff-c0e9014b158d93a6e2949908b7d7b7636d14bfdbd7c49157fe1ff07cf18622caL345-L357) [[5]](diffhunk://#diff-c0e9014b158d93a6e2949908b7d7b7636d14bfdbd7c49157fe1ff07cf18622caL385-L394)

**Test Updates:**
* Updated landing page test fixtures and test cases to remove MTP-related stat items and links, ensuring tests reflect the new UI and data. [[1]](diffhunk://#diff-8c1dc660d182fe3766fb23669b055905648051312401fd3ca051b02848d33b6bL19-L24) [[2]](diffhunk://#diff-f995c07db7bd7ddef94a4e04bdc90d44a9ad349f3caa892e0cde605fdbf9d73dL110-R110)