### PR TITLE
Portal 2877

### DIFF
--- a/docs/static-content.md
+++ b/docs/static-content.md
@@ -67,7 +67,7 @@ className: "navMobileItem clickable"
 
 ### `landingData.md`
 
-Any of these keys may be present; missing keys keep the portal JS defaults.
+Any of these keys may be present; missing keys stay empty (no JS copy fallback).
 
 | Key | Notes |
 |-----|--------|
@@ -89,7 +89,9 @@ Image fields should be absolute URLs. If `img` / `mobile` are omitted, the porta
 
 ## Failure behavior
 
-If a file is missing, YAML is invalid, or the network request fails, the Hub keeps the built-in JS content in `src/bento/landingPageData.js` and `src/bento/globalHeaderData.js` so the site never goes blank.
+There is **no JS copy fallback**. If a file is missing, YAML is invalid, or the network request fails, homepage/nav content stays empty until valid remote MD loads. Local webpack images may still attach to remote rows by `id` / carousel `content` when the MD omits `img` / `mobile` URLs.
+
+Host `landingData.md` and `navData.md` on the static-contents branch before expecting a filled homepage or nav.
 
 ## Verify after deploy
 

--- a/docs/static-content.md
+++ b/docs/static-content.md
@@ -1,0 +1,106 @@
+# Static content updates (homepage & navigation)
+
+Hub homepage and primary navigation copy can be updated **without a portal code release** by editing YAML inside markdown files hosted in [`CBIIT/CCDI_Hub_Static_Contents`](https://github.com/CBIIT/CCDI_Hub_Static_Contents).
+
+The portal loads these files at runtime from `REACT_APP_STATIC_CONTENT_URL` (see `public/injectEnv.js` / `config/inject.template.js`).
+
+| File | Purpose |
+|------|---------|
+| `landingData.md` | Homepage hero, section titles, stats labels, resource cards, carousel |
+| `navData.md` | Primary nav + Resources / About submenus |
+
+Content format is **YAML front matter only** (markdown body is ignored). This matches gray-matter usage on other Hub pages while keeping structured lists easy to edit.
+
+## Environment URL
+
+| Env | Typical base |
+|-----|----------------|
+| Local / Dev | `https://raw.githubusercontent.com/CBIIT/CCDI_Hub_Static_Contents/dev` |
+| Prod | Same repo, production branch (set via k8s / `inject.template.js`) |
+
+Fetch URLs look like:
+
+```text
+${REACT_APP_STATIC_CONTENT_URL}/landingData.md?ts=<timestamp>
+${REACT_APP_STATIC_CONTENT_URL}/navData.md?ts=<timestamp>
+```
+
+The `?ts=` query busts CDN/browser caches so merges show up on the next page load.
+
+## `{{C3DC}}` token
+
+Use `{{C3DC}}` anywhere a C3DC base URL is needed. The portal substitutes `REACT_APP_C3DC` (no trailing slash) at parse time.
+
+Examples:
+
+```yaml
+link: "{{C3DC}}/explore"
+link: "{{C3DC}}/"
+```
+
+## Permissions & deploy
+
+1. Open a PR against the env branch in `CCDI_Hub_Static_Contents` (team members with administered permissions).
+2. Edit only the YAML between the `---` fences in `landingData.md` or `navData.md`.
+3. Merge the PR.
+4. Hard-refresh the Hub (or open a new session). No portal rebuild is required for content-only changes.
+
+Portal releases are only required when enabling or changing the **code** that reads these files.
+
+## YAML field cheat sheet
+
+### `navData.md`
+
+Required: `primary` (non-empty list).
+
+| Key | Shape |
+|-----|--------|
+| `primary[]` | `name`, `link`, `className` (`navMobileItem`, `navMobileItem clickable`, or `cart`) |
+| `resources[]` | `name`, `link` (becomes `navMobileSubItem`) |
+| `about[]` | Section: `name` + `children[]` with `name`, `link` **or** flat `name`/`link` |
+
+Quote values that contain `:` or special characters:
+
+```yaml
+className: "navMobileItem clickable"
+```
+
+### `landingData.md`
+
+Any of these keys may be present; missing keys keep the portal JS defaults.
+
+| Key | Notes |
+|-----|--------|
+| `heroTitle`, `heroSubtitle` | Hero headline / supporting text (`heroSubtitle` may use `\|` multiline) |
+| `introTitle3`, `introButtonTitle` | About buttons under the hero |
+| `latestUpdatesTitle`, `resourceTitle`, `applicationsTitle`, `cloudResourcesTitle` | Section headings |
+| `statsNote` | Footnote under stats |
+| `stats[]` | `title`, `detail`, `link`; optional static `num` (live MCI/CCDC counts still filled by the app) |
+| `resourcesApplications[]` / `resourcesCloud[]` | `id`, `title`, `subtitle?`, `content`, `link`, `img?`, `noLink?` |
+| `carousel[]` | `content`, `link`, `img?`, `mobile?` |
+
+HTML in titles (e.g. stats line breaks) must be quoted:
+
+```yaml
+title: "Reported Cases Under Age 40<br>(1995-2020)"
+```
+
+Image fields should be absolute URLs. If `img` / `mobile` are omitted, the portal keeps the bundled local asset for that `id` / carousel `content` when possible.
+
+## Failure behavior
+
+If a file is missing, YAML is invalid, or the network request fails, the Hub keeps the built-in JS content in `src/bento/landingPageData.js` and `src/bento/globalHeaderData.js` so the site never goes blank.
+
+## Verify after deploy
+
+1. Confirm the raw GitHub URL returns the new YAML (open in browser).
+2. Load Hub home: hero text, resource cards, carousel labels/links.
+3. Check primary nav: Explore / Studies C3DC links, Resources submenu, nested About sections.
+4. Confirm no portal redeploy was needed for the content change.
+
+## Fixtures in this repo
+
+Copy-starting samples (for tests and for seeding the static-contents repo):
+
+- `tests/fixtures/landing/landingMarkdownSamples.js`
+- `tests/fixtures/nav/navMarkdownSamples.js`

--- a/src/bento/landingPageData.js
+++ b/src/bento/landingPageData.js
@@ -47,8 +47,9 @@ const C3DC_BASE_URL = String(env.REACT_APP_C3DC || '').replace(/\/$/, '');
 
 export const introData = {
   landingIntroPic: landingImg,
-  introTitle1: 'Discover CCDI applications, data, resources, and other tools',
-  introTitle2: 'Explore the CCDI Hub by selecting an available resource on the Hub Wheel',
+  // Word-split with <br /> in landingView; keep three short words for the hero stack.
+  introTitle1: 'Discover CCDI Resources',
+  introTitle2: 'Explore the CCDI Hub, its applications,\nand analytic tools by selecting an\navailable resource',
   introTitle3: 'ABOUT CCDI HUB',
   introButtonTitle: 'ABOUT CCDI',
 };
@@ -90,7 +91,7 @@ export const resourcesAppliationsListData = [
     title: 'Childhood Cancer Clinical Data Commons',
     subtitle: 'C3DC',
     content: 'A searchable database of childhood cancer demographics and phenotypic clinical data.',
-    link: 'https://clinicalcommons.ccdi.cancer.gov/',
+    link: `${C3DC_BASE_URL}/`,
     img: c3dcLogo,
   },
   {

--- a/src/bento/parseNavMarkdown.js
+++ b/src/bento/parseNavMarkdown.js
@@ -1,0 +1,72 @@
+import matter from 'gray-matter';
+import resolveContentTokens from '../utils/resolveContentTokens';
+
+/**
+ * Parse navData.md — YAML front matter only.
+ * Returns null when primary nav is missing so callers keep JS fallbacks.
+ */
+export default function parseNavMarkdown(rawMarkdown) {
+  if (rawMarkdown == null || String(rawMarkdown).trim() === '') {
+    return null;
+  }
+
+  let data;
+  try {
+    const source = String(rawMarkdown).replace(/^\uFEFF/, '');
+    ({ data } = matter(source));
+  } catch (_error) {
+    return null;
+  }
+
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return null;
+  }
+
+  const resolved = resolveContentTokens(data);
+  if (!Array.isArray(resolved.primary) || resolved.primary.length === 0) {
+    return null;
+  }
+
+  const navMobileList = resolved.primary.map((item) => ({
+    name: item.name != null ? String(item.name) : '',
+    link: item.link != null ? String(item.link) : '',
+    className: item.className != null ? String(item.className) : 'navMobileItem',
+  }));
+
+  const resources = Array.isArray(resolved.resources)
+    ? resolved.resources.map((item) => ({
+      name: item.name != null ? String(item.name) : '',
+      link: item.link != null ? String(item.link) : '',
+      className: 'navMobileSubItem',
+    }))
+    : [];
+
+  const about = Array.isArray(resolved.about)
+    ? resolved.about.map((section) => {
+      if (Array.isArray(section.children) && section.children.length > 0) {
+        return {
+          name: section.name != null ? String(section.name) : '',
+          className: 'navMobileSubSection',
+          children: section.children.map((child) => ({
+            name: child.name != null ? String(child.name) : '',
+            link: child.link != null ? String(child.link) : '',
+            className: 'navMobileSubItem',
+          })),
+        };
+      }
+      return {
+        name: section.name != null ? String(section.name) : '',
+        link: section.link != null ? String(section.link) : '',
+        className: 'navMobileSubItem',
+      };
+    })
+    : [];
+
+  return {
+    navMobileList,
+    navbarSublists: {
+      Resources: resources,
+      About: about,
+    },
+  };
+}

--- a/src/components/ResponsiveHeader/HeaderMobile.js
+++ b/src/components/ResponsiveHeader/HeaderMobile.js
@@ -6,8 +6,10 @@ import SearchBar from '../ResponsiveHeader/components/SearchBarMobile';
 import menuClearIcon from '../../assets/header/Menu_Cancel_Icon.svg';
 import rightArrowIcon from '../../assets/header/Right_Arrow.svg';
 import leftArrowIcon from '../../assets/header/Left_Arrow.svg';
-import { navMobileList, navbarSublists, navBarCartData, flattenNavbarSublist } from '../../bento/globalHeaderData'
+import { navBarCartData, flattenNavbarSublist } from '../../bento/globalHeaderData'
 import { USGovBannerData } from '../../bento/globalHeaderData';
+import { useNavContent } from './NavContentContext';
+
 
 const HeaderBanner = styled.div`
   width: 100%;
@@ -225,6 +227,7 @@ const USGovBanner = styled.div`
 
 const Header = () => {
   const path = useLocation().pathname;
+  const { navMobileList, navbarSublists } = useNavContent();
   const [clickTitle, setClickTitle] = useState('');
   const [navMobileDisplay, setNavMobileDisplay] = useState('none');
   const [navbarMobileList, setNavbarMobileList] = useState(navMobileList);
@@ -246,7 +249,7 @@ const Header = () => {
     } else {
       setNavbarMobileList(navMobileList);
     }
-  }, [clickTitle]);
+  }, [clickTitle, navbarSublists, navMobileList]);
 
   return (
     <>

--- a/src/components/ResponsiveHeader/HeaderTablet.js
+++ b/src/components/ResponsiveHeader/HeaderTablet.js
@@ -6,8 +6,10 @@ import SearchBar from '../ResponsiveHeader/components/SearchBarTablet';
 import menuClearIcon from '../../assets/header/Menu_Cancel_Icon.svg';
 import rightArrowIcon from '../../assets/header/Right_Arrow.svg';
 import leftArrowIcon from '../../assets/header/Left_Arrow.svg';
-import { navMobileList, navbarSublists, navBarCartData, flattenNavbarSublist } from '../../bento/globalHeaderData'
+import { navBarCartData, flattenNavbarSublist } from '../../bento/globalHeaderData'
 import { USGovBannerData } from '../../bento/globalHeaderData';
+import { useNavContent } from './NavContentContext';
+
 
 const HeaderBanner = styled.div`
   width: 100%;
@@ -224,6 +226,7 @@ const USGovBanner = styled.div`
 
 const Header = () => {
   const path = useLocation().pathname;
+  const { navMobileList, navbarSublists } = useNavContent();
   const [clickTitle, setClickTitle] = useState('');
   const [navMobileDisplay, setNavMobileDisplay] = useState('none');
   const [navbarMobileList, setNavbarMobileList] = useState(navMobileList);
@@ -245,7 +248,7 @@ const Header = () => {
     } else {
       setNavbarMobileList(navMobileList);
     }
-  }, [clickTitle]);
+  }, [clickTitle, navbarSublists, navMobileList]);
 
   return (
     <>

--- a/src/components/ResponsiveHeader/NavContentContext.js
+++ b/src/components/ResponsiveHeader/NavContentContext.js
@@ -3,22 +3,23 @@ import React, {
 } from 'react';
 import axios from 'axios';
 import env from '../../utils/env';
-import {
-  navMobileList as defaultNavMobileList,
-  navbarSublists as defaultNavbarSublists,
-} from '../../bento/globalHeaderData';
 import parseNavMarkdown from '../../bento/parseNavMarkdown';
 
 const NAV_URL = `${env.REACT_APP_STATIC_CONTENT_URL}/navData.md`;
 
-const NavContentContext = createContext({
-  navMobileList: defaultNavMobileList,
-  navbarSublists: defaultNavbarSublists,
-});
+const emptyNav = {
+  navMobileList: [],
+  navbarSublists: {
+    Resources: [],
+    About: [],
+  },
+};
+
+const NavContentContext = createContext(emptyNav);
 
 export function NavContentProvider({ children }) {
-  const [navMobileList, setNavMobileList] = useState(defaultNavMobileList);
-  const [navbarSublists, setNavbarSublists] = useState(defaultNavbarSublists);
+  const [navMobileList, setNavMobileList] = useState(emptyNav.navMobileList);
+  const [navbarSublists, setNavbarSublists] = useState(emptyNav.navbarSublists);
 
   useEffect(() => {
     let cancelled = false;
@@ -27,27 +28,24 @@ export function NavContentProvider({ children }) {
         const fileUrl = `${NAV_URL}?ts=${new Date().getTime()}`;
         const result = await axios.get(fileUrl);
         const parsed = parseNavMarkdown(result.data);
-        if (!cancelled && parsed) {
-          // Preserve cart item from defaults when remote omits it.
-          const hasCart = parsed.navMobileList.some((item) => item.className === 'cart');
-          const mergedPrimary = hasCart
-            ? parsed.navMobileList
-            : [
-              ...parsed.navMobileList,
-              ...defaultNavMobileList.filter((item) => item.className === 'cart'),
-            ];
-          setNavMobileList(mergedPrimary);
+        if (cancelled) {
+          return;
+        }
+        if (parsed) {
+          setNavMobileList(parsed.navMobileList);
           setNavbarSublists({
-            Resources: parsed.navbarSublists.Resources.length
-              ? parsed.navbarSublists.Resources
-              : defaultNavbarSublists.Resources,
-            About: parsed.navbarSublists.About.length
-              ? parsed.navbarSublists.About
-              : defaultNavbarSublists.About,
+            Resources: parsed.navbarSublists.Resources || [],
+            About: parsed.navbarSublists.About || [],
           });
+        } else {
+          setNavMobileList(emptyNav.navMobileList);
+          setNavbarSublists(emptyNav.navbarSublists);
         }
       } catch (_error) {
-        /* keep JS defaults */
+        if (!cancelled) {
+          setNavMobileList(emptyNav.navMobileList);
+          setNavbarSublists(emptyNav.navbarSublists);
+        }
       }
     };
     fetchNav();

--- a/src/components/ResponsiveHeader/NavContentContext.js
+++ b/src/components/ResponsiveHeader/NavContentContext.js
@@ -1,0 +1,75 @@
+import React, {
+  createContext, useContext, useEffect, useState, useMemo,
+} from 'react';
+import axios from 'axios';
+import env from '../../utils/env';
+import {
+  navMobileList as defaultNavMobileList,
+  navbarSublists as defaultNavbarSublists,
+} from '../../bento/globalHeaderData';
+import parseNavMarkdown from '../../bento/parseNavMarkdown';
+
+const NAV_URL = `${env.REACT_APP_STATIC_CONTENT_URL}/navData.md`;
+
+const NavContentContext = createContext({
+  navMobileList: defaultNavMobileList,
+  navbarSublists: defaultNavbarSublists,
+});
+
+export function NavContentProvider({ children }) {
+  const [navMobileList, setNavMobileList] = useState(defaultNavMobileList);
+  const [navbarSublists, setNavbarSublists] = useState(defaultNavbarSublists);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchNav = async () => {
+      try {
+        const fileUrl = `${NAV_URL}?ts=${new Date().getTime()}`;
+        const result = await axios.get(fileUrl);
+        const parsed = parseNavMarkdown(result.data);
+        if (!cancelled && parsed) {
+          // Preserve cart item from defaults when remote omits it.
+          const hasCart = parsed.navMobileList.some((item) => item.className === 'cart');
+          const mergedPrimary = hasCart
+            ? parsed.navMobileList
+            : [
+              ...parsed.navMobileList,
+              ...defaultNavMobileList.filter((item) => item.className === 'cart'),
+            ];
+          setNavMobileList(mergedPrimary);
+          setNavbarSublists({
+            Resources: parsed.navbarSublists.Resources.length
+              ? parsed.navbarSublists.Resources
+              : defaultNavbarSublists.Resources,
+            About: parsed.navbarSublists.About.length
+              ? parsed.navbarSublists.About
+              : defaultNavbarSublists.About,
+          });
+        }
+      } catch (_error) {
+        /* keep JS defaults */
+      }
+    };
+    fetchNav();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const value = useMemo(() => ({
+    navMobileList,
+    navbarSublists,
+  }), [navMobileList, navbarSublists]);
+
+  return (
+    <NavContentContext.Provider value={value}>
+      {children}
+    </NavContentContext.Provider>
+  );
+}
+
+export function useNavContent() {
+  return useContext(NavContentContext);
+}
+
+export default NavContentContext;

--- a/src/components/ResponsiveHeader/components/NavbarDesktop.js
+++ b/src/components/ResponsiveHeader/components/NavbarDesktop.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useLocation, NavLink } from 'react-router-dom';
 import styled from 'styled-components';
-import { navMobileList, navbarSublists, isAboutPathActive } from '../../../bento/globalHeaderData';
+import { isAboutPathActive } from '../../../bento/globalHeaderData';
+import { useNavContent } from '../NavContentContext';
 
 const Nav = styled.div`
     top: 0;
@@ -284,7 +285,8 @@ const useOutsideAlerter = (ref) => {
 
 const NavBar = () => {
   const path = useLocation().pathname;
-  const isAbout = isAboutPathActive(path);
+  const { navMobileList, navbarSublists } = useNavContent();
+  const isAbout = isAboutPathActive(path, navbarSublists.About);
   const [clickedTitle, setClickedTitle] = useState("");
   const dropdownSelection = useRef(null);
   const clickableObject = navMobileList.filter(item => item.className === 'navMobileItem clickable');

--- a/src/components/ResponsiveHeader/index.js
+++ b/src/components/ResponsiveHeader/index.js
@@ -7,6 +7,7 @@ import {
 import HeaderDesktop from './HeaderDesktop';
 import HeaderTablet from './HeaderTablet';
 import HeaderMobile from './HeaderMobile';
+import { NavContentProvider } from './NavContentContext';
 
 const HeaderContainer = styled.div`
  @media (min-width: 1024px) {
@@ -64,17 +65,19 @@ const Header = () => {
     dispatch(initCart());
   }, []);
   return (
-    <HeaderContainer>
-      <div className="desktop">
-        <HeaderDesktop />
-      </div>
-      <div className="tablet">
-        <HeaderTablet />
-      </div>
-      <div className="mobile">
-        <HeaderMobile />
-      </div>
-    </HeaderContainer>
+    <NavContentProvider>
+      <HeaderContainer>
+        <div className="desktop">
+          <HeaderDesktop />
+        </div>
+        <div className="tablet">
+          <HeaderTablet />
+        </div>
+        <div className="mobile">
+          <HeaderMobile />
+        </div>
+      </HeaderContainer>
+    </NavContentProvider>
   )
 };
 

--- a/src/pages/landing/LandingContentContext.js
+++ b/src/pages/landing/LandingContentContext.js
@@ -1,36 +1,18 @@
 import React, { createContext, useContext, useMemo } from 'react';
-import {
-  introData as defaultIntroData,
-  titleData as defaultTitleData,
-  statsNote as defaultStatsNote,
-  resourcesAppliationsListData as defaultResourcesApplications,
-  resourcesCloudListData as defaultResourcesCloud,
-  carouselList as defaultCarouselList,
-} from '../../bento/landingPageData';
+import { createEmptyLandingContent } from './parseLandingMarkdown';
 
-const LandingContentContext = createContext({
-  introData: defaultIntroData,
-  titleData: defaultTitleData,
-  statsNote: defaultStatsNote,
-  resourcesAppliationsListData: defaultResourcesApplications,
-  resourcesCloudListData: defaultResourcesCloud,
-  carouselList: defaultCarouselList,
-});
+const emptyLandingContent = createEmptyLandingContent();
+
+const LandingContentContext = createContext(emptyLandingContent);
 
 export function LandingContentProvider({ value, children }) {
-  const merged = useMemo(() => ({
-    introData: (value && value.introData) || defaultIntroData,
-    titleData: (value && value.titleData) || defaultTitleData,
-    statsNote: value && value.statsNote != null ? value.statsNote : defaultStatsNote,
-    resourcesAppliationsListData:
-      (value && value.resourcesAppliationsListData) || defaultResourcesApplications,
-    resourcesCloudListData:
-      (value && value.resourcesCloudListData) || defaultResourcesCloud,
-    carouselList: (value && value.carouselList) || defaultCarouselList,
-  }), [value]);
+  const content = useMemo(
+    () => (value != null ? value : emptyLandingContent),
+    [value],
+  );
 
   return (
-    <LandingContentContext.Provider value={merged}>
+    <LandingContentContext.Provider value={content}>
       {children}
     </LandingContentContext.Provider>
   );

--- a/src/pages/landing/LandingContentContext.js
+++ b/src/pages/landing/LandingContentContext.js
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import {
+  introData as defaultIntroData,
+  titleData as defaultTitleData,
+  statsNote as defaultStatsNote,
+  resourcesAppliationsListData as defaultResourcesApplications,
+  resourcesCloudListData as defaultResourcesCloud,
+  carouselList as defaultCarouselList,
+} from '../../bento/landingPageData';
+
+const LandingContentContext = createContext({
+  introData: defaultIntroData,
+  titleData: defaultTitleData,
+  statsNote: defaultStatsNote,
+  resourcesAppliationsListData: defaultResourcesApplications,
+  resourcesCloudListData: defaultResourcesCloud,
+  carouselList: defaultCarouselList,
+});
+
+export function LandingContentProvider({ value, children }) {
+  const merged = useMemo(() => ({
+    introData: (value && value.introData) || defaultIntroData,
+    titleData: (value && value.titleData) || defaultTitleData,
+    statsNote: value && value.statsNote != null ? value.statsNote : defaultStatsNote,
+    resourcesAppliationsListData:
+      (value && value.resourcesAppliationsListData) || defaultResourcesApplications,
+    resourcesCloudListData:
+      (value && value.resourcesCloudListData) || defaultResourcesCloud,
+    carouselList: (value && value.carouselList) || defaultCarouselList,
+  }), [value]);
+
+  return (
+    <LandingContentContext.Provider value={merged}>
+      {children}
+    </LandingContentContext.Provider>
+  );
+}
+
+export function useLandingContent() {
+  return useContext(LandingContentContext);
+}
+
+export default LandingContentContext;

--- a/src/pages/landing/component/carousel.js
+++ b/src/pages/landing/component/carousel.js
@@ -358,6 +358,7 @@ const Carousel = () => {
 
     const nextItem = () => {
         const list = document.getElementById("carouselList");
+        if (!list || !list.lastChild) return;
         const lastitem = list.lastChild;
         list.removeChild(lastitem);
         list.insertBefore(lastitem, list.firstChild);
@@ -373,6 +374,7 @@ const Carousel = () => {
 
     const prevItem = () => {
         const list = document.getElementById("carouselList");
+        if (!list || !list.firstChild) return;
         const firstitem = list.firstChild;
         list.removeChild(firstitem);
         list.appendChild(firstitem);
@@ -414,9 +416,14 @@ const Carousel = () => {
     }
 
     useEffect(() => {
-        if (rCarouselList.length === 0) {
-            setRCarouselList(getRandomList(carouselList.sort((a, b) => a.content.localeCompare(b.content))));
+        if (rCarouselList.length === 0 && carouselList.length > 0) {
+            setRCarouselList(getRandomList(
+                [...carouselList].sort((a, b) => String(a.content).localeCompare(String(b.content))),
+            ));
         }
+    }, [carouselList]);
+
+    useEffect(() => {
         if (!isVisible) {
             clearInterval(timer);
         }

--- a/src/pages/landing/component/carousel.js
+++ b/src/pages/landing/component/carousel.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
 import usePageVisibility from "./PageVisibility";
 import styled from 'styled-components';
-import { carouselList } from '../../../bento/landingPageData'
+import { useLandingContent } from '../LandingContentContext';
 import exportIcon from '../../../assets/landing/Export_Icon.svg';
 import arrowIcon from '../../../assets/landing/arrow.svg';
 
@@ -336,6 +336,7 @@ const getRandomList = (itemList) => {
 };
 
 const Carousel = () => {
+    const { carouselList } = useLandingContent();
     const [rCarouselList, setRCarouselList] = useState([]);
     const [pause, setPause] = useState(false);
     const isVisible = usePageVisibility();

--- a/src/pages/landing/component/heroMobile.js
+++ b/src/pages/landing/component/heroMobile.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import usePageVisibility from "./PageVisibility";
-import { carouselList } from '../../../bento/landingPageData';
+import { useLandingContent } from '../LandingContentContext';
 import exportIconText from '../../../assets/landing/Export_Icon_White.svg';
 import startIcon from '../../../assets/icons/Start_Icon.svg';
 import pauseIcon from '../../../assets/icons/Pause_Icon.svg';
@@ -260,6 +260,7 @@ const HeroMobileSection = styled.div`
 `;
 
 const HeroMobile = () => {
+    const { carouselList, introData } = useLandingContent();
     const isVisible = usePageVisibility();
     const [pause, setPause] = useState(false);
 
@@ -344,7 +345,9 @@ const HeroMobile = () => {
                     CCDI {window.innerWidth < 872 ? <br/> : <></>}
                     Resources
                 </h1>
-                <div className='introTitle2'>Explore the CCDI Hub </div>
+                <div className='introTitle2'>
+                  {(introData.introTitle2 || 'Explore the CCDI Hub ').split('\n')[0].trim()}
+                </div>
                 <div id="mcarouselList" className='carouselMobileList'>
                     {
                         carouselList.map((mcarouselItem, idx) => {

--- a/src/pages/landing/component/heroMobile.js
+++ b/src/pages/landing/component/heroMobile.js
@@ -283,6 +283,7 @@ const HeroMobile = () => {
 
     const nextItem = () => {
         const list = document.getElementById("mcarouselList");
+        if (!list || !list.firstChild) return;
         const firstitem = list.firstChild;
         list.removeChild(firstitem);
         list.appendChild(firstitem);
@@ -297,6 +298,7 @@ const HeroMobile = () => {
 
     const prevItem = () => {
       const list = document.getElementById("mcarouselList");
+      if (!list || !list.lastChild) return;
       const lastitem = list.lastChild;
       list.removeChild(lastitem);
       list.insertBefore(lastitem, list.firstChild);
@@ -341,12 +343,19 @@ const HeroMobile = () => {
                 <div className='carouselMobileListCover' />
                 <div className='carouselMobileListCoverColor' />
                 <h1 className='introTitle1'>
-                    Discover<br/>
-                    CCDI {window.innerWidth < 872 ? <br/> : <></>}
-                    Resources
+                  {String(introData.introTitle1 || '')
+                    .split(/\s+/)
+                    .filter(Boolean)
+                    .reduce((acc, word, idx, arr) => {
+                      acc.push(word);
+                      if (idx < arr.length - 1) {
+                        acc.push(<br key={`mbr_${idx}`} />);
+                      }
+                      return acc;
+                    }, [])}
                 </h1>
                 <div className='introTitle2'>
-                  {(introData.introTitle2 || 'Explore the CCDI Hub ').split('\n')[0].trim()}
+                  {String(introData.introTitle2 || '').split('\n')[0].trim()}
                 </div>
                 <div id="mcarouselList" className='carouselMobileList'>
                     {

--- a/src/pages/landing/component/latestUpdate.js
+++ b/src/pages/landing/component/latestUpdate.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import ReactHtmlParser from 'html-react-parser';
 import usePageVisibility from "./PageVisibility";
 // import { altList, srcList, newsList, releaseNotesList } from '../../../bento/newsData';
-import { titleData } from '../../../bento/landingPageData';
+import { useLandingContent } from '../LandingContentContext';
 import exportIconText from '../../../assets/landing/Export_Icon_White.svg';
 import startIcon from '../../../assets/icons/Start_Icon.svg';
 import pauseIcon from '../../../assets/icons/Pause_Icon.svg';
@@ -394,6 +394,7 @@ const TitleContainer = styled.div`
 `;
 
 const LatestUpdate = ({newsList, srcList, releaseNotesList, altList}) => {
+    const { titleData } = useLandingContent();
     const [hoverItem, setHoverItem] = useState("");
     const [pause, setPause] = useState(true);
     const [rLatestlList, setRLatestlList] = useState([]);

--- a/src/pages/landing/landingController.js
+++ b/src/pages/landing/landingController.js
@@ -1,22 +1,43 @@
 import React, { useEffect, useState } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { connect } from 'react-redux';
-import env from '../../utils/env'
-import yaml from "js-yaml";
-import axios from "axios";
+import env from '../../utils/env';
+import yaml from 'js-yaml';
+import axios from 'axios';
 import { fetchReleaseNotesData, mergeReleaseNotesLists } from '../releaseNotePage/parseReleaseNotesMarkdown';
 import { CircularProgress } from '@material-ui/core';
-import { statsData } from '../../bento/landingPageData';
+import {
+  introData as defaultIntroData,
+  titleData as defaultTitleData,
+  statsData as defaultStatsData,
+  statsNote as defaultStatsNote,
+  resourcesAppliationsListData as defaultResourcesApplications,
+  resourcesCloudListData as defaultResourcesCloud,
+  carouselList as defaultCarouselList,
+  LANDING_DATA_QUERY,
+} from '../../bento/landingPageData';
+import parseLandingMarkdown, { mergeLandingContent } from './parseLandingMarkdown';
+import { LandingContentProvider } from './LandingContentContext';
 import LandingView from './landingView';
-import { LANDING_DATA_QUERY } from '../../bento/landingPageData';
 
-const CCDCurl ='https://datacatalog.ccdi.cancer.gov/service/datasets/count';
+const CCDCurl = 'https://datacatalog.ccdi.cancer.gov/service/datasets/count';
 const NEWS_URL = `${env.REACT_APP_STATIC_CONTENT_URL}/newsData.yaml`;
+const LANDING_MD_URL = `${env.REACT_APP_STATIC_CONTENT_URL}/landingData.md`;
+
+const defaultLandingContent = {
+  introData: defaultIntroData,
+  titleData: defaultTitleData,
+  statsData: defaultStatsData,
+  statsNote: defaultStatsNote,
+  resourcesAppliationsListData: defaultResourcesApplications,
+  resourcesCloudListData: defaultResourcesCloud,
+  carouselList: defaultCarouselList,
+};
 
 const getDashData = () => {
   const client = useApolloClient();
   async function getData() {
-    let result = await client.query({
+    const result = await client.query({
       query: LANDING_DATA_QUERY,
       variables: {},
     })
@@ -37,6 +58,7 @@ const getDashData = () => {
       const result = await axios.get(fileUrl);
       resultData = yaml.safeLoad(result.data) || {};
     } catch (_error) {
+      /* empty */
     }
     const { releaseNotesList, ccdiDataUpdatesList } = await fetchReleaseNotesData();
     return {
@@ -45,46 +67,84 @@ const getDashData = () => {
     };
   }
 
-  const [statsDataNew, setStatsDataNew] = useState(statsData);
+  async function getLandingContent() {
+    try {
+      const fileUrl = `${LANDING_MD_URL}?ts=${new Date().getTime()}`;
+      const result = await axios.get(fileUrl);
+      const parsed = parseLandingMarkdown(result.data);
+      return mergeLandingContent(parsed, defaultLandingContent);
+    } catch (_error) {
+      return defaultLandingContent;
+    }
+  }
+
+  const [landingContent, setLandingContent] = useState(defaultLandingContent);
+  const [statsDataNew, setStatsDataNew] = useState(defaultStatsData);
   const [data, setData] = useState([]);
 
   useEffect(() => {
     const controller = new AbortController();
-    getCCDC().then((result) => {
-      let newStatList = statsDataNew;
-      newStatList[0].num = result.data;
-      setStatsDataNew([...newStatList]);
+
+    getLandingContent().then((content) => {
+      setLandingContent(content);
+      setStatsDataNew(content.statsData.map((row) => ({ ...row })));
     });
-    getData().then((result) => {
-      let newStatList = statsDataNew;
-      const MCICount = result.numberOfMCICount;
-      newStatList[1].num = MCICount;
-      setStatsDataNew([...newStatList]);
-    });
+
     getNewsData().then((resultData) => {
       setData(resultData);
     });
+
     return () => controller.abort();
-  },[]);
-  return { statsDataNew, data };
+  }, []);
+
+  useEffect(() => {
+    getCCDC().then((result) => {
+      setStatsDataNew((prev) => {
+        const next = prev.map((row) => ({ ...row }));
+        if (next[0]) {
+          next[0] = { ...next[0], num: result.data };
+        }
+        return next;
+      });
+    });
+    getData().then((result) => {
+      setStatsDataNew((prev) => {
+        const next = prev.map((row) => ({ ...row }));
+        if (next[1]) {
+          next[1] = { ...next[1], num: result.numberOfMCICount };
+        }
+        return next;
+      });
+    });
+  }, []);
+
+  return { statsDataNew, data, landingContent };
 };
 
 const LandingController = (() => {
-  const { statsDataNew, data } = getDashData();
+  const { statsDataNew, data, landingContent } = getDashData();
 
   if (!statsDataNew) {
-    return (<div style={{"height": "1200px","paddingTop": "10px"}}><div style={{"margin": "auto","display": "flex","maxWidth": "1800px"}}><CircularProgress /></div></div>);
+    return (
+      <div style={{ height: '1200px', paddingTop: '10px' }}>
+        <div style={{ margin: 'auto', display: 'flex', maxWidth: '1800px' }}>
+          <CircularProgress />
+        </div>
+      </div>
+    );
   }
 
   return (
-    <LandingView
-      statsData={statsDataNew}
-      newsData={data}
-    />
+    <LandingContentProvider value={landingContent}>
+      <LandingView
+        statsData={statsDataNew}
+        newsData={data}
+      />
+    </LandingContentProvider>
   );
 });
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = () => ({
 });
 
 export default connect(mapStateToProps, null)(LandingController);

--- a/src/pages/landing/landingController.js
+++ b/src/pages/landing/landingController.js
@@ -7,16 +7,19 @@ import axios from 'axios';
 import { fetchReleaseNotesData, mergeReleaseNotesLists } from '../releaseNotePage/parseReleaseNotesMarkdown';
 import { CircularProgress } from '@material-ui/core';
 import {
-  introData as defaultIntroData,
-  titleData as defaultTitleData,
-  statsData as defaultStatsData,
-  statsNote as defaultStatsNote,
-  resourcesAppliationsListData as defaultResourcesApplications,
-  resourcesCloudListData as defaultResourcesCloud,
-  carouselList as defaultCarouselList,
+  introData as assetIntroData,
+  titleData as assetTitleData,
+  statsData as assetStatsData,
+  statsNote as assetStatsNote,
+  resourcesAppliationsListData as assetResourcesApplications,
+  resourcesCloudListData as assetResourcesCloud,
+  carouselList as assetCarouselList,
   LANDING_DATA_QUERY,
 } from '../../bento/landingPageData';
-import parseLandingMarkdown, { mergeLandingContent } from './parseLandingMarkdown';
+import parseLandingMarkdown, {
+  createEmptyLandingContent,
+  mergeLandingContent,
+} from './parseLandingMarkdown';
 import { LandingContentProvider } from './LandingContentContext';
 import LandingView from './landingView';
 
@@ -24,15 +27,18 @@ const CCDCurl = 'https://datacatalog.ccdi.cancer.gov/service/datasets/count';
 const NEWS_URL = `${env.REACT_APP_STATIC_CONTENT_URL}/newsData.yaml`;
 const LANDING_MD_URL = `${env.REACT_APP_STATIC_CONTENT_URL}/landingData.md`;
 
-const defaultLandingContent = {
-  introData: defaultIntroData,
-  titleData: defaultTitleData,
-  statsData: defaultStatsData,
-  statsNote: defaultStatsNote,
-  resourcesAppliationsListData: defaultResourcesApplications,
-  resourcesCloudListData: defaultResourcesCloud,
-  carouselList: defaultCarouselList,
+/** Local webpack assets only — never used as copy fallback when MD is missing. */
+const landingAssetDefaults = {
+  introData: assetIntroData,
+  titleData: assetTitleData,
+  statsData: assetStatsData,
+  statsNote: assetStatsNote,
+  resourcesAppliationsListData: assetResourcesApplications,
+  resourcesCloudListData: assetResourcesCloud,
+  carouselList: assetCarouselList,
 };
+
+const emptyLandingContent = createEmptyLandingContent(landingAssetDefaults);
 
 const getDashData = () => {
   const client = useApolloClient();
@@ -72,14 +78,17 @@ const getDashData = () => {
       const fileUrl = `${LANDING_MD_URL}?ts=${new Date().getTime()}`;
       const result = await axios.get(fileUrl);
       const parsed = parseLandingMarkdown(result.data);
-      return mergeLandingContent(parsed, defaultLandingContent);
+      if (!parsed) {
+        return emptyLandingContent;
+      }
+      return mergeLandingContent(parsed, landingAssetDefaults);
     } catch (_error) {
-      return defaultLandingContent;
+      return emptyLandingContent;
     }
   }
 
-  const [landingContent, setLandingContent] = useState(defaultLandingContent);
-  const [statsDataNew, setStatsDataNew] = useState(defaultStatsData);
+  const [landingContent, setLandingContent] = useState(emptyLandingContent);
+  const [statsDataNew, setStatsDataNew] = useState([]);
   const [data, setData] = useState([]);
 
   useEffect(() => {
@@ -124,7 +133,7 @@ const getDashData = () => {
 const LandingController = (() => {
   const { statsDataNew, data, landingContent } = getDashData();
 
-  if (!statsDataNew) {
+  if (statsDataNew == null) {
     return (
       <div style={{ height: '1200px', paddingTop: '10px' }}>
         <div style={{ margin: 'auto', display: 'flex', maxWidth: '1800px' }}>

--- a/src/pages/landing/landingView.js
+++ b/src/pages/landing/landingView.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
-import { introData, titleData, statsNote, resourcesAppliationsListData, resourcesCloudListData } from '../../bento/landingPageData';
+import { useLandingContent } from './LandingContentContext';
 import ReactHtmlParser from 'html-react-parser';
 import Carousel from '../landing/component/carousel';
 import HeroMobile from '../landing/component/heroMobile'
@@ -874,6 +874,13 @@ const LandingView = ({
   statsData,
   newsData
 }) => {
+  const {
+    introData,
+    titleData,
+    statsNote,
+    resourcesAppliationsListData,
+    resourcesCloudListData,
+  } = useLandingContent();
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -890,11 +897,26 @@ const LandingView = ({
         <FirstContainer>
           <IntroContainer>
             <IntroTextContainer>
-              <h1 className='introTextTitle1'>Discover<br/>CCDI<br/>Resources</h1>
+              <h1 className='introTextTitle1'>
+                {(introData.introTitle1 || 'Discover CCDI Resources')
+                  .split(/\s+/)
+                  .reduce((acc, word, idx, arr) => {
+                    acc.push(word);
+                    if (idx < arr.length - 1) {
+                      acc.push(<br key={`br_${idx}`} />);
+                    }
+                    return acc;
+                  }, [])}
+              </h1>
               <div className='introTextTitle2'>
-                <div>Explore the CCDI Hub, its applications,</div>
-                <div>and analytic tools by selecting an</div>
-                <div>available resource</div>
+                {(introData.introTitle2
+                  || 'Explore the CCDI Hub, its applications, and analytic tools by selecting an available resource')
+                  .split('\n')
+                  .map((line) => line.trim())
+                  .filter(Boolean)
+                  .map((line, idx) => (
+                    <div key={`hero_sub_${idx}`}>{line}</div>
+                  ))}
               </div>
               <IntroAboutButtonContainer>
                 <div><a className='introAboutButton' href="/about">{introData.introTitle3}</a></div>

--- a/src/pages/landing/landingView.js
+++ b/src/pages/landing/landingView.js
@@ -898,8 +898,9 @@ const LandingView = ({
           <IntroContainer>
             <IntroTextContainer>
               <h1 className='introTextTitle1'>
-                {(introData.introTitle1 || 'Discover CCDI Resources')
+                {String(introData.introTitle1 || '')
                   .split(/\s+/)
+                  .filter(Boolean)
                   .reduce((acc, word, idx, arr) => {
                     acc.push(word);
                     if (idx < arr.length - 1) {
@@ -909,8 +910,7 @@ const LandingView = ({
                   }, [])}
               </h1>
               <div className='introTextTitle2'>
-                {(introData.introTitle2
-                  || 'Explore the CCDI Hub, its applications, and analytic tools by selecting an available resource')
+                {String(introData.introTitle2 || '')
                   .split('\n')
                   .map((line) => line.trim())
                   .filter(Boolean)

--- a/src/pages/landing/parseLandingMarkdown.js
+++ b/src/pages/landing/parseLandingMarkdown.js
@@ -1,0 +1,176 @@
+import matter from 'gray-matter';
+import resolveContentTokens from '../../utils/resolveContentTokens';
+
+/**
+ * Parse landingData.md — YAML front matter only (markdown body ignored).
+ * Returns null when required structure is missing so callers keep JS fallbacks.
+ */
+export default function parseLandingMarkdown(rawMarkdown) {
+  if (rawMarkdown == null || String(rawMarkdown).trim() === '') {
+    return null;
+  }
+
+  let data;
+  try {
+    const source = String(rawMarkdown).replace(/^\uFEFF/, '');
+    ({ data } = matter(source));
+  } catch (_error) {
+    return null;
+  }
+
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return null;
+  }
+
+  const resolved = resolveContentTokens(data);
+
+  const hasAnyContent = Boolean(
+    resolved.heroTitle
+    || resolved.heroSubtitle
+    || resolved.introTitle3
+    || resolved.latestUpdatesTitle
+    || resolved.resourceTitle
+    || (Array.isArray(resolved.stats) && resolved.stats.length)
+    || (Array.isArray(resolved.resourcesApplications) && resolved.resourcesApplications.length)
+    || (Array.isArray(resolved.carousel) && resolved.carousel.length),
+  );
+
+  if (!hasAnyContent) {
+    return null;
+  }
+
+  return {
+    heroTitle: resolved.heroTitle != null ? String(resolved.heroTitle) : undefined,
+    heroSubtitle: resolved.heroSubtitle != null ? String(resolved.heroSubtitle) : undefined,
+    introTitle3: resolved.introTitle3 != null ? String(resolved.introTitle3) : undefined,
+    introButtonTitle: resolved.introButtonTitle != null ? String(resolved.introButtonTitle) : undefined,
+    latestUpdatesTitle: resolved.latestUpdatesTitle != null
+      ? String(resolved.latestUpdatesTitle) : undefined,
+    resourceTitle: resolved.resourceTitle != null ? String(resolved.resourceTitle) : undefined,
+    applicationsTitle: resolved.applicationsTitle != null
+      ? String(resolved.applicationsTitle) : undefined,
+    cloudResourcesTitle: resolved.cloudResourcesTitle != null
+      ? String(resolved.cloudResourcesTitle) : undefined,
+    statsNote: resolved.statsNote != null ? String(resolved.statsNote) : undefined,
+    stats: Array.isArray(resolved.stats) ? resolved.stats : undefined,
+    resourcesApplications: Array.isArray(resolved.resourcesApplications)
+      ? resolved.resourcesApplications : undefined,
+    resourcesCloud: Array.isArray(resolved.resourcesCloud)
+      ? resolved.resourcesCloud : undefined,
+    carousel: Array.isArray(resolved.carousel) ? resolved.carousel : undefined,
+  };
+}
+
+/**
+ * Merge remote landing YAML over local JS defaults.
+ * Remote image URLs win when present; otherwise keep webpack-imported local assets by id/content.
+ */
+export function mergeLandingContent(parsed, defaults) {
+  if (!parsed) {
+    return defaults;
+  }
+
+  const introData = {
+    ...defaults.introData,
+    ...(parsed.heroTitle != null ? { introTitle1: parsed.heroTitle } : {}),
+    ...(parsed.heroSubtitle != null ? { introTitle2: parsed.heroSubtitle } : {}),
+    ...(parsed.introTitle3 != null ? { introTitle3: parsed.introTitle3 } : {}),
+    ...(parsed.introButtonTitle != null ? { introButtonTitle: parsed.introButtonTitle } : {}),
+  };
+
+  const titleData = {
+    ...defaults.titleData,
+    ...(parsed.latestUpdatesTitle != null
+      ? { latestUpdatesTitle: parsed.latestUpdatesTitle } : {}),
+    ...(parsed.resourceTitle != null ? { resourceTitle: parsed.resourceTitle } : {}),
+    ...(parsed.applicationsTitle != null
+      ? { applicationsTitle: parsed.applicationsTitle } : {}),
+    ...(parsed.cloudResourcesTitle != null
+      ? { cloudResourcesTitle: parsed.cloudResourcesTitle } : {}),
+  };
+
+  const statsData = mergeStats(parsed.stats, defaults.statsData);
+  const statsNote = parsed.statsNote != null ? parsed.statsNote : defaults.statsNote;
+  const resourcesAppliationsListData = mergeResourceList(
+    parsed.resourcesApplications,
+    defaults.resourcesAppliationsListData,
+  );
+  const resourcesCloudListData = mergeResourceList(
+    parsed.resourcesCloud,
+    defaults.resourcesCloudListData,
+  );
+  const carouselList = mergeCarouselList(parsed.carousel, defaults.carouselList);
+
+  return {
+    introData,
+    titleData,
+    statsData,
+    statsNote,
+    resourcesAppliationsListData,
+    resourcesCloudListData,
+    carouselList,
+  };
+}
+
+function mergeStats(remote, local) {
+  if (!Array.isArray(remote) || remote.length === 0) {
+    return local;
+  }
+  return remote.map((item, idx) => {
+    const fallback = local[idx] || {};
+    return {
+      num: item.num != null ? item.num : (fallback.num != null ? fallback.num : ''),
+      title: item.title != null ? String(item.title) : (fallback.title || ''),
+      detail: item.detail != null ? String(item.detail) : (fallback.detail || ''),
+      link: item.link != null ? String(item.link) : (fallback.link || ''),
+    };
+  });
+}
+
+function mergeResourceList(remote, local) {
+  if (!Array.isArray(remote) || remote.length === 0) {
+    return local;
+  }
+  return remote.map((item) => {
+    const localMatch = Array.isArray(local)
+      ? local.find((entry) => entry.id && item.id && entry.id === item.id)
+      : null;
+    return {
+      id: item.id != null ? String(item.id) : (localMatch && localMatch.id),
+      title: item.title != null ? String(item.title) : (localMatch && localMatch.title) || '',
+      ...(item.subtitle != null || (localMatch && localMatch.subtitle)
+        ? { subtitle: item.subtitle != null ? String(item.subtitle) : localMatch.subtitle }
+        : {}),
+      content: item.content != null
+        ? String(item.content)
+        : (localMatch && localMatch.content) || '',
+      link: item.link != null ? String(item.link) : (localMatch && localMatch.link) || '',
+      img: item.img || (localMatch && localMatch.img),
+      ...(item.noLink != null || (localMatch && localMatch.noLink)
+        ? { noLink: item.noLink != null ? Boolean(item.noLink) : localMatch.noLink }
+        : {}),
+    };
+  });
+}
+
+function mergeCarouselList(remote, local) {
+  if (!Array.isArray(remote) || remote.length === 0) {
+    return local;
+  }
+  return remote.map((item, idx) => {
+    const byContent = Array.isArray(local)
+      ? local.find((entry) => entry.content && item.content
+        && entry.content === item.content)
+      : null;
+    const byIndex = Array.isArray(local) ? local[idx] : null;
+    const localMatch = byContent || byIndex;
+    return {
+      content: item.content != null
+        ? String(item.content)
+        : (localMatch && localMatch.content) || '',
+      link: item.link != null ? String(item.link) : (localMatch && localMatch.link) || '',
+      img: item.img || (localMatch && localMatch.img),
+      mobile: item.mobile || (localMatch && localMatch.mobile),
+    };
+  });
+}

--- a/src/pages/landing/parseLandingMarkdown.js
+++ b/src/pages/landing/parseLandingMarkdown.js
@@ -2,8 +2,37 @@ import matter from 'gray-matter';
 import resolveContentTokens from '../../utils/resolveContentTokens';
 
 /**
+ * Empty landing shell (no JS copy fallback). Asset maps may still be passed into
+ * mergeLandingContent so remote rows can attach local webpack images by id/content.
+ */
+export function createEmptyLandingContent(assetDefaults = {}) {
+  const introPic = assetDefaults.introData && assetDefaults.introData.landingIntroPic;
+  return {
+    introData: {
+      landingIntroPic: introPic,
+      introTitle1: '',
+      introTitle2: '',
+      introTitle3: '',
+      introButtonTitle: '',
+    },
+    titleData: {
+      latestUpdatesTitle: '',
+      resourceTitle: '',
+      applicationsTitle: '',
+      cloudResourcesTitle: '',
+      aboutTitle: '',
+    },
+    statsData: [],
+    statsNote: '',
+    resourcesAppliationsListData: [],
+    resourcesCloudListData: [],
+    carouselList: [],
+  };
+}
+
+/**
  * Parse landingData.md — YAML front matter only (markdown body ignored).
- * Returns null when required structure is missing so callers keep JS fallbacks.
+ * Returns null when required structure is missing.
  */
 export default function parseLandingMarkdown(rawMarkdown) {
   if (rawMarkdown == null || String(rawMarkdown).trim() === '') {
@@ -62,16 +91,19 @@ export default function parseLandingMarkdown(rawMarkdown) {
 }
 
 /**
- * Merge remote landing YAML over local JS defaults.
- * Remote image URLs win when present; otherwise keep webpack-imported local assets by id/content.
+ * Build landing props from remote YAML only. Missing sections stay empty.
+ * Local assetDefaults are used only to attach webpack images by id/content when
+ * the remote row omits img/mobile URLs.
  */
-export function mergeLandingContent(parsed, defaults) {
+export function mergeLandingContent(parsed, assetDefaults = {}) {
   if (!parsed) {
-    return defaults;
+    return createEmptyLandingContent(assetDefaults);
   }
 
+  const empty = createEmptyLandingContent(assetDefaults);
+
   const introData = {
-    ...defaults.introData,
+    ...empty.introData,
     ...(parsed.heroTitle != null ? { introTitle1: parsed.heroTitle } : {}),
     ...(parsed.heroSubtitle != null ? { introTitle2: parsed.heroSubtitle } : {}),
     ...(parsed.introTitle3 != null ? { introTitle3: parsed.introTitle3 } : {}),
@@ -79,7 +111,7 @@ export function mergeLandingContent(parsed, defaults) {
   };
 
   const titleData = {
-    ...defaults.titleData,
+    ...empty.titleData,
     ...(parsed.latestUpdatesTitle != null
       ? { latestUpdatesTitle: parsed.latestUpdatesTitle } : {}),
     ...(parsed.resourceTitle != null ? { resourceTitle: parsed.resourceTitle } : {}),
@@ -89,86 +121,83 @@ export function mergeLandingContent(parsed, defaults) {
       ? { cloudResourcesTitle: parsed.cloudResourcesTitle } : {}),
   };
 
-  const statsData = mergeStats(parsed.stats, defaults.statsData);
-  const statsNote = parsed.statsNote != null ? parsed.statsNote : defaults.statsNote;
-  const resourcesAppliationsListData = mergeResourceList(
-    parsed.resourcesApplications,
-    defaults.resourcesAppliationsListData,
-  );
-  const resourcesCloudListData = mergeResourceList(
-    parsed.resourcesCloud,
-    defaults.resourcesCloudListData,
-  );
-  const carouselList = mergeCarouselList(parsed.carousel, defaults.carouselList);
+  const assetLists = {
+    statsData: assetDefaults.statsData || [],
+    resourcesAppliationsListData: assetDefaults.resourcesAppliationsListData || [],
+    resourcesCloudListData: assetDefaults.resourcesCloudListData || [],
+    carouselList: assetDefaults.carouselList || [],
+  };
 
   return {
     introData,
     titleData,
-    statsData,
-    statsNote,
-    resourcesAppliationsListData,
-    resourcesCloudListData,
-    carouselList,
+    statsData: mergeStats(parsed.stats, assetLists.statsData),
+    statsNote: parsed.statsNote != null ? parsed.statsNote : '',
+    resourcesAppliationsListData: mergeResourceList(
+      parsed.resourcesApplications,
+      assetLists.resourcesAppliationsListData,
+    ),
+    resourcesCloudListData: mergeResourceList(
+      parsed.resourcesCloud,
+      assetLists.resourcesCloudListData,
+    ),
+    carouselList: mergeCarouselList(parsed.carousel, assetLists.carouselList),
   };
 }
 
-function mergeStats(remote, local) {
+function mergeStats(remote, localAssets) {
   if (!Array.isArray(remote) || remote.length === 0) {
-    return local;
+    return [];
   }
   return remote.map((item, idx) => {
-    const fallback = local[idx] || {};
+    const asset = localAssets[idx] || {};
     return {
-      num: item.num != null ? item.num : (fallback.num != null ? fallback.num : ''),
-      title: item.title != null ? String(item.title) : (fallback.title || ''),
-      detail: item.detail != null ? String(item.detail) : (fallback.detail || ''),
-      link: item.link != null ? String(item.link) : (fallback.link || ''),
+      num: item.num != null ? item.num : (asset.num != null ? asset.num : ''),
+      title: item.title != null ? String(item.title) : '',
+      detail: item.detail != null ? String(item.detail) : '',
+      link: item.link != null ? String(item.link) : '',
     };
   });
 }
 
-function mergeResourceList(remote, local) {
+function mergeResourceList(remote, localAssets) {
   if (!Array.isArray(remote) || remote.length === 0) {
-    return local;
+    return [];
   }
   return remote.map((item) => {
-    const localMatch = Array.isArray(local)
-      ? local.find((entry) => entry.id && item.id && entry.id === item.id)
+    const localMatch = Array.isArray(localAssets)
+      ? localAssets.find((entry) => entry.id && item.id && entry.id === item.id)
       : null;
     return {
       id: item.id != null ? String(item.id) : (localMatch && localMatch.id),
-      title: item.title != null ? String(item.title) : (localMatch && localMatch.title) || '',
-      ...(item.subtitle != null || (localMatch && localMatch.subtitle)
-        ? { subtitle: item.subtitle != null ? String(item.subtitle) : localMatch.subtitle }
+      title: item.title != null ? String(item.title) : '',
+      ...(item.subtitle != null
+        ? { subtitle: String(item.subtitle) }
         : {}),
-      content: item.content != null
-        ? String(item.content)
-        : (localMatch && localMatch.content) || '',
-      link: item.link != null ? String(item.link) : (localMatch && localMatch.link) || '',
+      content: item.content != null ? String(item.content) : '',
+      link: item.link != null ? String(item.link) : '',
       img: item.img || (localMatch && localMatch.img),
-      ...(item.noLink != null || (localMatch && localMatch.noLink)
-        ? { noLink: item.noLink != null ? Boolean(item.noLink) : localMatch.noLink }
+      ...(item.noLink != null
+        ? { noLink: Boolean(item.noLink) }
         : {}),
     };
   });
 }
 
-function mergeCarouselList(remote, local) {
+function mergeCarouselList(remote, localAssets) {
   if (!Array.isArray(remote) || remote.length === 0) {
-    return local;
+    return [];
   }
   return remote.map((item, idx) => {
-    const byContent = Array.isArray(local)
-      ? local.find((entry) => entry.content && item.content
+    const byContent = Array.isArray(localAssets)
+      ? localAssets.find((entry) => entry.content && item.content
         && entry.content === item.content)
       : null;
-    const byIndex = Array.isArray(local) ? local[idx] : null;
+    const byIndex = Array.isArray(localAssets) ? localAssets[idx] : null;
     const localMatch = byContent || byIndex;
     return {
-      content: item.content != null
-        ? String(item.content)
-        : (localMatch && localMatch.content) || '',
-      link: item.link != null ? String(item.link) : (localMatch && localMatch.link) || '',
+      content: item.content != null ? String(item.content) : '',
+      link: item.link != null ? String(item.link) : '',
       img: item.img || (localMatch && localMatch.img),
       mobile: item.mobile || (localMatch && localMatch.mobile),
     };

--- a/src/utils/resolveContentTokens.js
+++ b/src/utils/resolveContentTokens.js
@@ -1,0 +1,41 @@
+import env from './env';
+
+const C3DC_TOKEN = /\{\{\s*C3DC\s*\}\}/g;
+
+function c3dcBase() {
+  return String(env.REACT_APP_C3DC || '').replace(/\/$/, '');
+}
+
+/**
+ * Replace `{{C3DC}}` in a string with the configured C3DC base URL (no trailing slash).
+ */
+export function resolveContentTokenString(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const base = c3dcBase();
+  return value.replace(C3DC_TOKEN, base);
+}
+
+/**
+ * Deep-replace `{{C3DC}}` in strings within plain objects/arrays.
+ */
+export default function resolveContentTokens(input) {
+  if (input == null) {
+    return input;
+  }
+  if (typeof input === 'string') {
+    return resolveContentTokenString(input);
+  }
+  if (Array.isArray(input)) {
+    return input.map((item) => resolveContentTokens(item));
+  }
+  if (typeof input === 'object') {
+    const out = {};
+    Object.keys(input).forEach((key) => {
+      out[key] = resolveContentTokens(input[key]);
+    });
+    return out;
+  }
+  return input;
+}

--- a/tests/bento/parseNavMarkdown.test.js
+++ b/tests/bento/parseNavMarkdown.test.js
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for parseNavMarkdown.
+ */
+
+jest.mock('../../src/utils/env', () => ({
+  __esModule: true,
+  default: {
+    REACT_APP_C3DC: 'https://c3dc.test.example',
+  },
+}));
+
+import parseNavMarkdown from '../../src/bento/parseNavMarkdown';
+import {
+  sampleNavMarkdownRaw,
+  sampleNavMarkdownEmpty,
+  sampleNavMarkdownNoPrimary,
+} from '../fixtures/nav/navMarkdownSamples';
+
+describe('parseNavMarkdown', () => {
+  it('should parse primary/resources/about and resolve {{C3DC}}', () => {
+    const parsed = parseNavMarkdown(sampleNavMarkdownRaw);
+    expect(parsed).not.toBeNull();
+    expect(parsed.navMobileList[1].link).toBe('https://c3dc.test.example/explore');
+    expect(parsed.navMobileList[2].link).toBe('https://c3dc.test.example/studies');
+    expect(parsed.navbarSublists.Resources[0].link).toBe('https://c3dc.test.example/');
+    expect(parsed.navbarSublists.Resources[0].className).toBe('navMobileSubItem');
+    expect(parsed.navbarSublists.About[0].className).toBe('navMobileSubSection');
+    expect(parsed.navbarSublists.About[0].children[0].link).toBe('/about');
+    expect(parsed.navbarSublists.About[1].children[1].link).toBe(
+      'https://c3dc.test.example/data_model',
+    );
+  });
+
+  it('should return null when primary is missing', () => {
+    expect(parseNavMarkdown(sampleNavMarkdownNoPrimary)).toBeNull();
+  });
+
+  it('should return null for empty front matter', () => {
+    expect(parseNavMarkdown(sampleNavMarkdownEmpty)).toBeNull();
+  });
+});

--- a/tests/components/ResponsiveHeader/HeaderMobile.test.js
+++ b/tests/components/ResponsiveHeader/HeaderMobile.test.js
@@ -32,16 +32,25 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import HeaderMobile from '../../../src/components/ResponsiveHeader/HeaderMobile';
+import NavContentContext from '../../../src/components/ResponsiveHeader/NavContentContext';
+import {
+  navMobileList,
+  navbarSublists,
+} from '../../../src/bento/globalHeaderData';
 
 function clickWithInnerText(element, text) {
   Object.defineProperty(element, 'innerText', { configurable: true, value: text });
   fireEvent.click(element);
 }
 
+const navValue = { navMobileList, navbarSublists };
+
 function renderAt(path) {
   return render(
     <MemoryRouter initialEntries={[path]}>
-      <HeaderMobile />
+      <NavContentContext.Provider value={navValue}>
+        <HeaderMobile />
+      </NavContentContext.Provider>
     </MemoryRouter>,
   );
 }

--- a/tests/components/ResponsiveHeader/HeaderTablet.test.js
+++ b/tests/components/ResponsiveHeader/HeaderTablet.test.js
@@ -32,16 +32,25 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import HeaderTablet from '../../../src/components/ResponsiveHeader/HeaderTablet';
+import NavContentContext from '../../../src/components/ResponsiveHeader/NavContentContext';
+import {
+  navMobileList,
+  navbarSublists,
+} from '../../../src/bento/globalHeaderData';
 
 function clickWithInnerText(element, text) {
   Object.defineProperty(element, 'innerText', { configurable: true, value: text });
   fireEvent.click(element);
 }
 
+const navValue = { navMobileList, navbarSublists };
+
 function renderAt(path) {
   return render(
     <MemoryRouter initialEntries={[path]}>
-      <HeaderTablet />
+      <NavContentContext.Provider value={navValue}>
+        <HeaderTablet />
+      </NavContentContext.Provider>
     </MemoryRouter>,
   );
 }

--- a/tests/components/ResponsiveHeader/NavContentContext.test.js
+++ b/tests/components/ResponsiveHeader/NavContentContext.test.js
@@ -1,0 +1,81 @@
+/**
+ * NavContentProvider — fetches navData.md and falls back to JS defaults.
+ */
+
+if (typeof global.MutationObserver === 'undefined') {
+  global.MutationObserver = class MutationObserver {
+    disconnect() {}
+    observe() {}
+    takeRecords() { return []; }
+  };
+}
+
+jest.mock('../../../src/utils/env', () => ({
+  __esModule: true,
+  default: {
+    REACT_APP_STATIC_CONTENT_URL: 'https://static.example.com',
+    REACT_APP_C3DC: 'https://c3dc.test.example',
+  },
+}));
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import axios from 'axios';
+import { NavContentProvider, useNavContent } from '../../../src/components/ResponsiveHeader/NavContentContext';
+import { sampleNavMarkdownRaw } from '../../fixtures/nav/navMarkdownSamples';
+
+jest.mock('axios');
+
+function NavProbe() {
+  const { navMobileList, navbarSublists } = useNavContent();
+  return (
+    <div>
+      <div data-testid="explore-link">{navMobileList.find((i) => i.name === 'Explore')?.link}</div>
+      <div data-testid="about-sections">{navbarSublists.About.length}</div>
+    </div>
+  );
+}
+
+describe('NavContentProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should load navData.md and expose resolved C3DC links', async () => {
+    axios.get.mockResolvedValue({ data: sampleNavMarkdownRaw });
+    render(
+      <NavContentProvider>
+        <NavProbe />
+      </NavContentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringMatching(/^https:\/\/static\.example\.com\/navData\.md\?ts=/),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('explore-link')).toHaveTextContent(
+        'https://c3dc.test.example/explore',
+      );
+    });
+    expect(Number(screen.getByTestId('about-sections').textContent)).toBeGreaterThan(0);
+  });
+
+  it('should keep JS defaults when navData.md fetch fails', async () => {
+    axios.get.mockRejectedValue(new Error('network'));
+    render(
+      <NavContentProvider>
+        <NavProbe />
+      </NavContentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalled();
+    });
+
+    expect(screen.getByTestId('explore-link').textContent).toContain('/explore');
+  });
+});

--- a/tests/components/ResponsiveHeader/NavContentContext.test.js
+++ b/tests/components/ResponsiveHeader/NavContentContext.test.js
@@ -1,5 +1,5 @@
 /**
- * NavContentProvider — fetches navData.md and falls back to JS defaults.
+ * NavContentProvider — fetches navData.md; no JS copy fallback on failure.
  */
 
 if (typeof global.MutationObserver === 'undefined') {
@@ -31,7 +31,8 @@ function NavProbe() {
   const { navMobileList, navbarSublists } = useNavContent();
   return (
     <div>
-      <div data-testid="explore-link">{navMobileList.find((i) => i.name === 'Explore')?.link}</div>
+      <div data-testid="explore-link">{navMobileList.find((i) => i.name === 'Explore')?.link || ''}</div>
+      <div data-testid="nav-count">{navMobileList.length}</div>
       <div data-testid="about-sections">{navbarSublists.About.length}</div>
     </div>
   );
@@ -64,7 +65,7 @@ describe('NavContentProvider', () => {
     expect(Number(screen.getByTestId('about-sections').textContent)).toBeGreaterThan(0);
   });
 
-  it('should keep JS defaults when navData.md fetch fails', async () => {
+  it('should leave nav empty when navData.md fetch fails', async () => {
     axios.get.mockRejectedValue(new Error('network'));
     render(
       <NavContentProvider>
@@ -76,6 +77,8 @@ describe('NavContentProvider', () => {
       expect(axios.get).toHaveBeenCalled();
     });
 
-    expect(screen.getByTestId('explore-link').textContent).toContain('/explore');
+    expect(screen.getByTestId('nav-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('explore-link')).toHaveTextContent('');
+    expect(screen.getByTestId('about-sections')).toHaveTextContent('0');
   });
 });

--- a/tests/components/ResponsiveHeader/components/NavbarDesktop.test.js
+++ b/tests/components/ResponsiveHeader/components/NavbarDesktop.test.js
@@ -14,14 +14,23 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import NavbarDesktop from '../../../../src/components/ResponsiveHeader/components/NavbarDesktop';
+import NavContentContext from '../../../../src/components/ResponsiveHeader/NavContentContext';
+import {
+  navMobileList,
+  navbarSublists,
+} from '../../../../src/bento/globalHeaderData';
 
 const C3DC_URL = 'https://clinicalcommons-dev.ccdi.cancer.gov';
+
+const navValue = { navMobileList, navbarSublists };
 
 describe('NavbarDesktop', () => {
   function renderNav(path = '/') {
     return render(
       <MemoryRouter initialEntries={[path]}>
-        <NavbarDesktop />
+        <NavContentContext.Provider value={navValue}>
+          <NavbarDesktop />
+        </NavContentContext.Provider>
       </MemoryRouter>,
     );
   }

--- a/tests/fixtures/landing/landingMarkdownSamples.js
+++ b/tests/fixtures/landing/landingMarkdownSamples.js
@@ -1,0 +1,71 @@
+/**
+ * Sample landingData.md (YAML front matter only) for parser / controller tests.
+ * Content managers can copy this shape into CCDI_Hub_Static_Contents/landingData.md.
+ */
+
+export const sampleLandingMarkdownRaw = `---
+heroTitle: Discover CCDI Resources
+heroSubtitle: |
+  Explore the CCDI Hub, its applications, and analytic tools by selecting an available resource
+introTitle3: ABOUT CCDI HUB
+introButtonTitle: ABOUT CCDI
+latestUpdatesTitle: Latest Updates
+resourceTitle: Resources
+applicationsTitle: CCDI-SUPPORTED RESOURCES
+cloudResourcesTitle: Other Resources
+statsNote: Counts for MCI participants in CCDI Hub and total MCI participants consented may differ.
+stats:
+  - title: Cataloged Datasets
+    detail: Childhood Cancer Data Catalog
+    link: https://datacatalog.ccdi.cancer.gov
+  - title: Participants with Available Genomic and Clinical Data
+    detail: Molecular Characterization Initiative
+    link: /MCI
+  - title: "Reported Cases Under Age 40<br>(1995-2020)"
+    detail: National Childhood Cancer Registry Explorer
+    link: https://nccrexplorer.ccdi.cancer.gov
+    num: 1700440
+resourcesApplications:
+  - id: c3dc
+    title: Childhood Cancer Clinical Data Commons
+    subtitle: C3DC
+    content: A searchable database of childhood cancer demographics and phenotypic clinical data.
+    link: "{{C3DC}}/"
+  - id: ccdc
+    title: Childhood Cancer Data Catalog
+    subtitle: CCDC
+    content: A searchable inventory of childhood cancer resources.
+    link: https://datacatalog.ccdi.cancer.gov
+  - id: mci
+    title: Molecular Characterization Initiative
+    subtitle: MCI
+    content: A program providing molecular testing for children, adolescents, and young adults with certain cancer types.
+    link: /MCI
+    noLink: true
+resourcesCloud:
+  - id: cgc
+    title: Cancer Genomics Cloud
+    subtitle: CGC
+    content: A cloud-based platform to access and analyze cancer research data.
+    link: https://www.cancergenomicscloud.org
+  - id: dbgap
+    title: Database of Genotypes and Phenotypes
+    subtitle: dbGaP
+    content: A database to store and distribute data and results from studies examining the interaction of genotypes and phenotypes.
+    link: https://www.ncbi.nlm.nih.gov/gap
+carousel:
+  - content: Childhood Cancer Clinical Data Commons
+    link: "{{C3DC}}"
+  - content: Molecular Characterization Initiative
+    link: /MCI
+---
+`;
+
+export const sampleLandingMarkdownEmpty = `---
+---
+`;
+
+export const sampleLandingMarkdownInvalid = `---
+heroTitle: [unclosed
+---
+`;

--- a/tests/fixtures/nav/navMarkdownSamples.js
+++ b/tests/fixtures/nav/navMarkdownSamples.js
@@ -1,0 +1,93 @@
+/**
+ * Sample navData.md (YAML front matter only) for parser / header tests.
+ * Content managers can copy this shape into CCDI_Hub_Static_Contents/navData.md.
+ */
+
+export const sampleNavMarkdownRaw = `---
+primary:
+  - name: Home
+    link: /home
+    className: navMobileItem
+  - name: Explore
+    link: "{{C3DC}}/explore"
+    className: navMobileItem
+  - name: Studies
+    link: "{{C3DC}}/studies"
+    className: navMobileItem
+  - name: Resources
+    link: ""
+    className: "navMobileItem clickable"
+  - name: News
+    link: /news
+    className: navMobileItem
+  - name: About
+    link: /about
+    className: "navMobileItem clickable"
+  - name: My File
+    link: /fileCentricCart
+    className: cart
+resources:
+  - name: Childhood Cancer Clinical Data Commons
+    link: "{{C3DC}}/"
+  - name: Childhood Cancer Data Catalog
+    link: https://datacatalog.ccdi.cancer.gov
+  - name: Molecular Characterization Initiative
+    link: /MCI
+  - name: National Childhood Cancer Registry Explorer
+    link: https://nccrexplorer.ccdi.cancer.gov
+  - name: CCDI Data Federation Resource
+    link: /data-federation-resource
+  - name: CCDI Participant Index
+    link: /ccdi-participant-index
+  - name: CCDI cBioPortal
+    link: https://cbioportal.ccdi.cancer.gov
+  - name: NCCR Data Platform
+    link: https://nccrdataplatform.ccdi.cancer.gov/home
+  - name: Pediatric Molecular Target Lists
+    link: /pmtl
+  - name: Tools
+    link: /tools
+  - name: CCDI Pediatric, Adolescent, and Young Adult Rare Cancer Study
+    link: /pediatric-adolescent-and-young-adult-rare-cancer-study
+about:
+  - name: About CCDI Hub
+    children:
+      - name: About CCDI Hub
+        link: /about
+      - name: Release Notes
+        link: /release-notes
+  - name: About CCDI Data
+    children:
+      - name: CCDI Data Ecosystem & AI Readiness (PDF)
+        link: /Ecosystem_AI_Readiness.pdf
+      - name: CCDI Data Model
+        link: "{{C3DC}}/data_model"
+      - name: CCDI Data Submission Guide (PDF)
+        link: /Submission_Guide.pdf
+      - name: CCDI Data Usage Policies & Terms
+        link: /data-usage-policies
+  - name: CCDI Knowledge and Training
+    children:
+      - name: CCDI Events Announcements
+        link: /ccdi-events-announcements
+      - name: CCDI-Supported Publications
+        link: /publications
+  - name: Help
+    children:
+      - name: CCDI FAQs
+        link: /faq
+      - name: User Guide
+        link: /user-guide.pdf
+---
+`;
+
+export const sampleNavMarkdownEmpty = `---
+---
+`;
+
+export const sampleNavMarkdownNoPrimary = `---
+resources:
+  - name: Tools
+    link: /tools
+---
+`;

--- a/tests/helpers/landingApiMocks.js
+++ b/tests/helpers/landingApiMocks.js
@@ -35,12 +35,14 @@ export function createLandingGraphqlQueryMock(overrides = {}) {
 }
 
 /**
- * axios.get for news YAML and release notes markdown — must be assigned after jest.mock in tests that mock axios.
+ * axios.get for news YAML, release notes markdown, and optional landingData.md.
+ * Must be assigned after jest.mock in tests that mock axios.
  */
 export function setupNewsYamlAxiosMock(overrides = {}) {
   const raw = overrides.newsYamlRaw ?? newsDataYamlRaw;
   const releaseNotesMarkdown = overrides.releaseNotesMarkdown ?? '';
   const ccdiDataUpdatesMarkdown = overrides.ccdiDataUpdatesMarkdown ?? '';
+  const landingMarkdown = overrides.landingMarkdown;
   axios.get = jest.fn((url) => {
     const pathPart = String(url).split('?')[0];
     if (pathPart.endsWith('/newsData.yaml')) {
@@ -51,6 +53,12 @@ export function setupNewsYamlAxiosMock(overrides = {}) {
     }
     if (pathPart.endsWith('/ccdiDataUpdates.md')) {
       return Promise.resolve({ data: ccdiDataUpdatesMarkdown });
+    }
+    if (pathPart.endsWith('/landingData.md')) {
+      if (landingMarkdown === undefined) {
+        return Promise.reject(new Error('landingData.md not available in test'));
+      }
+      return Promise.resolve({ data: landingMarkdown });
     }
     return Promise.reject(new Error(`Unexpected axios.get URL in test: ${url}`));
   });

--- a/tests/pages/landing/component/carousel.test.js
+++ b/tests/pages/landing/component/carousel.test.js
@@ -3,20 +3,29 @@ import { MemoryRouter } from 'react-router-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Carousel from '../../../../src/pages/landing/component/carousel';
+import { LandingContentProvider } from '../../../../src/pages/landing/LandingContentContext';
 
 jest.mock('../../../../src/pages/landing/component/PageVisibility', () => ({
   __esModule: true,
   default: jest.fn(() => true),
 }));
 
-jest.mock('../../../../src/bento/landingPageData', () => ({
-  carouselList: [
-    { content: 'Internal One', link: '/about', img: 'img-1' },
-    { content: 'External Two', link: 'https://example.test/two', img: 'img-2' },
-    { content: 'Internal Three', link: '/news', img: 'img-3' },
-    { content: 'External Four', link: 'https://example.test/four', img: 'img-4' },
-  ],
-}));
+const carouselList = [
+  { content: 'Internal One', link: '/about', img: 'img-1' },
+  { content: 'External Two', link: 'https://example.test/two', img: 'img-2' },
+  { content: 'Internal Three', link: '/news', img: 'img-3' },
+  { content: 'External Four', link: 'https://example.test/four', img: 'img-4' },
+];
+
+function renderCarousel() {
+  return render(
+    <MemoryRouter>
+      <LandingContentProvider value={{ carouselList }}>
+        <Carousel />
+      </LandingContentProvider>
+    </MemoryRouter>,
+  );
+}
 
 describe('Carousel', () => {
   beforeEach(() => {
@@ -29,11 +38,7 @@ describe('Carousel', () => {
   });
 
   it('should render carousel items and toggle pause/start state', () => {
-    render(
-      <MemoryRouter>
-        <Carousel />
-      </MemoryRouter>,
-    );
+    renderCarousel();
 
     expect(screen.getByText('Internal One')).toBeInTheDocument();
     expect(screen.getByText('External Two')).toBeInTheDocument();
@@ -44,11 +49,7 @@ describe('Carousel', () => {
   });
 
   it('should support manual up/down slide controls', () => {
-    const { container } = render(
-      <MemoryRouter>
-        <Carousel />
-      </MemoryRouter>,
-    );
+    const { container } = renderCarousel();
 
     const upButton = container.querySelector('.upButton');
     const downButton = container.querySelector('.downButton');

--- a/tests/pages/landing/component/heroMobile.test.js
+++ b/tests/pages/landing/component/heroMobile.test.js
@@ -2,19 +2,32 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import HeroMobile from '../../../../src/pages/landing/component/heroMobile';
+import { LandingContentProvider } from '../../../../src/pages/landing/LandingContentContext';
 
 jest.mock('../../../../src/pages/landing/component/PageVisibility', () => ({
   __esModule: true,
   default: jest.fn(() => true),
 }));
 
-jest.mock('../../../../src/bento/landingPageData', () => ({
+const heroContent = {
+  introData: {
+    introTitle1: 'Discover CCDI Resources',
+    introTitle2: 'Explore the CCDI Hub',
+  },
   carouselList: [
     { content: 'Card One', link: 'https://example.test/one', mobile: 'm1' },
     { content: 'Card Two', link: 'https://example.test/two', mobile: 'm2' },
     { content: 'Card Three', link: 'https://example.test/three', mobile: 'm3' },
   ],
-}));
+};
+
+function renderHeroMobile() {
+  return render(
+    <LandingContentProvider value={heroContent}>
+      <HeroMobile />
+    </LandingContentProvider>,
+  );
+}
 
 describe('HeroMobile', () => {
   beforeEach(() => {
@@ -32,14 +45,14 @@ describe('HeroMobile', () => {
   });
 
   it('should render hero title and carousel cards', () => {
-    render(<HeroMobile />);
+    renderHeroMobile();
     expect(screen.getByText(/Discover/)).toBeInTheDocument();
     expect(screen.getByText('Card One')).toBeInTheDocument();
     expect(screen.getByText('Card Two')).toBeInTheDocument();
   });
 
   it('should toggle pause button style and support arrows', () => {
-    const { container } = render(<HeroMobile />);
+    const { container } = renderHeroMobile();
     const pauseButton = container.querySelector('.pauseButtonContainer');
     const arrowButtons = container.querySelectorAll('.arrowButtonContainer');
     const list = container.querySelector('#mcarouselList');

--- a/tests/pages/landing/component/latestUpdate.test.js
+++ b/tests/pages/landing/component/latestUpdate.test.js
@@ -2,14 +2,11 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import LatestUpdate from '../../../../src/pages/landing/component/latestUpdate';
+import { LandingContentProvider } from '../../../../src/pages/landing/LandingContentContext';
 
 jest.mock('../../../../src/pages/landing/component/PageVisibility', () => ({
   __esModule: true,
   default: jest.fn(() => true),
-}));
-
-jest.mock('../../../../src/bento/landingPageData', () => ({
-  titleData: { latestUpdatesTitle: 'Latest Updates' },
 }));
 
 const newsList = [
@@ -24,6 +21,20 @@ const releaseNotesList = [
 
 const srcList = { img1: 's1', img2: 's2', img3: 's3', img4: 's4' };
 const altList = { img1: 'a1', img2: 'a2', img3: 'a3', img4: 'a4' };
+
+function renderLatestUpdate(props = {}) {
+  return render(
+    <LandingContentProvider value={{ titleData: { latestUpdatesTitle: 'Latest Updates' } }}>
+      <LatestUpdate
+        newsList={newsList}
+        srcList={srcList}
+        releaseNotesList={releaseNotesList}
+        altList={altList}
+        {...props}
+      />
+    </LandingContentProvider>,
+  );
+}
 
 describe('LatestUpdate', () => {
   beforeEach(() => {
@@ -40,14 +51,7 @@ describe('LatestUpdate', () => {
   });
 
   it('should render title and latest update cards', async () => {
-    const { container } = render(
-      <LatestUpdate
-        newsList={newsList}
-        srcList={srcList}
-        releaseNotesList={releaseNotesList}
-        altList={altList}
-      />,
-    );
+    const { container } = renderLatestUpdate();
 
     expect(screen.getByText('Latest Updates')).toBeInTheDocument();
     await waitFor(() => {
@@ -56,14 +60,7 @@ describe('LatestUpdate', () => {
   });
 
   it('should support carousel controls and pause toggle', async () => {
-    const { container } = render(
-      <LatestUpdate
-        newsList={newsList}
-        srcList={srcList}
-        releaseNotesList={releaseNotesList}
-        altList={altList}
-      />,
-    );
+    const { container } = renderLatestUpdate();
     await waitFor(() => {
       expect(container.querySelector('#latestList')).toBeInTheDocument();
     });

--- a/tests/pages/landing/landingController.test.js
+++ b/tests/pages/landing/landingController.test.js
@@ -134,4 +134,34 @@ describe('LandingController (mocked count APIs)', () => {
       expect.objectContaining({ query: LANDING_DATA_QUERY }),
     );
   });
+
+  it('should request landingData.md with cache-bust query', async () => {
+    renderLandingController();
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringMatching(/\/landingData\.md\?ts=/),
+      );
+    });
+  });
+
+  it('should overlay hero title from landingData.md when fetch succeeds', async () => {
+    setupNewsYamlAxiosMock({
+      landingMarkdown: `---
+heroTitle: Remote Hero Title Here
+heroSubtitle: Remote subtitle from markdown
+introTitle3: ABOUT CCDI HUB
+introButtonTitle: ABOUT CCDI
+---
+`,
+    });
+
+    renderLandingController();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Remote');
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Hero');
+      expect(screen.getByText(/Remote subtitle from markdown/)).toBeInTheDocument();
+    });
+  });
 });

--- a/tests/pages/landing/landingController.test.js
+++ b/tests/pages/landing/landingController.test.js
@@ -22,6 +22,7 @@ import {
   landingDataQueryData,
 } from '../../fixtures/landing/apiResponses';
 import { createCcdcFetchMock, setupNewsYamlAxiosMock } from '../../helpers/landingApiMocks';
+import { sampleLandingMarkdownRaw } from '../../fixtures/landing/landingMarkdownSamples';
 
 // Ensure MutationObserver exists for RTL async helpers (e.g. waitFor) in this test env
 if (typeof global.MutationObserver === 'undefined') {
@@ -57,7 +58,7 @@ jest.mock('@apollo/client', () => {
 jest.mock('../../../src/utils/env', () => ({
   REACT_APP_STATIC_CONTENT_URL: 'https://static.example.com/',
 }));
-setupNewsYamlAxiosMock();
+setupNewsYamlAxiosMock({ landingMarkdown: sampleLandingMarkdownRaw });
 
 // Minimal Redux store for connected LandingController (mapStateToProps is empty)
 const rootReducer = combineReducers({
@@ -85,7 +86,7 @@ beforeEach(() => {
   mockQuery.mockClear();
   mockQuery.mockImplementation(() => Promise.resolve({ data: landingDataQueryData }));
   axios.get.mockClear();
-  setupNewsYamlAxiosMock();
+  setupNewsYamlAxiosMock({ landingMarkdown: sampleLandingMarkdownRaw });
   global.fetch = createCcdcFetchMock();
 });
 
@@ -162,6 +163,23 @@ introButtonTitle: ABOUT CCDI
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Remote');
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Hero');
       expect(screen.getByText(/Remote subtitle from markdown/)).toBeInTheDocument();
+    });
+  });
+
+  it('should leave hero empty when landingData.md is unavailable', async () => {
+    setupNewsYamlAxiosMock();
+
+    renderLandingController();
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringMatching(/\/landingData\.md\?ts=/),
+      );
+    });
+
+    await waitFor(() => {
+      const heroHeading = screen.getByRole('heading', { level: 1 });
+      expect(heroHeading).toHaveTextContent('');
     });
   });
 });

--- a/tests/pages/landing/landingView.test.js
+++ b/tests/pages/landing/landingView.test.js
@@ -11,6 +11,15 @@ import { MemoryRouter } from 'react-router-dom';
 import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import LandingView from '../../../src/pages/landing/landingView';
+import { LandingContentProvider } from '../../../src/pages/landing/LandingContentContext';
+import {
+  introData,
+  titleData,
+  statsNote,
+  resourcesAppliationsListData,
+  resourcesCloudListData,
+  carouselList,
+} from '../../../src/bento/landingPageData';
 import {
   defaultLandingStatsData,
   defaultLandingNewsData,
@@ -27,11 +36,22 @@ jest.mock('../../../src/pages/landing/component/latestUpdate', () => function La
   return <div data-testid="latest-update" />;
 });
 
+const landingContentForView = {
+  introData,
+  titleData,
+  statsNote,
+  resourcesAppliationsListData,
+  resourcesCloudListData,
+  carouselList,
+};
+
 function renderLandingView(props = {}) {
   const { statsData = defaultLandingStatsData, newsData = defaultLandingNewsData } = props;
   return render(
     <MemoryRouter>
-      <LandingView statsData={statsData} newsData={newsData} />
+      <LandingContentProvider value={landingContentForView}>
+        <LandingView statsData={statsData} newsData={newsData} />
+      </LandingContentProvider>
     </MemoryRouter>,
   );
 }

--- a/tests/pages/landing/parseLandingMarkdown.test.js
+++ b/tests/pages/landing/parseLandingMarkdown.test.js
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for parseLandingMarkdown / mergeLandingContent.
+ */
+
+jest.mock('../../../src/utils/env', () => ({
+  __esModule: true,
+  default: {
+    REACT_APP_C3DC: 'https://c3dc.test.example',
+  },
+}));
+
+import parseLandingMarkdown, {
+  mergeLandingContent,
+} from '../../../src/pages/landing/parseLandingMarkdown';
+import {
+  sampleLandingMarkdownRaw,
+  sampleLandingMarkdownEmpty,
+} from '../../fixtures/landing/landingMarkdownSamples';
+
+const defaults = {
+  introData: {
+    introTitle1: 'fallback title',
+    introTitle2: 'fallback subtitle',
+    introTitle3: 'FALLBACK ABOUT',
+    introButtonTitle: 'FALLBACK BTN',
+  },
+  titleData: {
+    latestUpdatesTitle: 'Fallback Updates',
+    resourceTitle: 'Fallback Resources',
+    applicationsTitle: 'FALLBACK APPS',
+    cloudResourcesTitle: 'Fallback Cloud',
+  },
+  statsData: [
+    { num: '', title: 'Local Stat', detail: 'Local', link: '/local' },
+  ],
+  statsNote: 'local note',
+  resourcesAppliationsListData: [
+    {
+      id: 'c3dc',
+      title: 'Local C3DC',
+      content: 'local',
+      link: '/local-c3dc',
+      img: 'local-img',
+    },
+  ],
+  resourcesCloudListData: [],
+  carouselList: [
+    {
+      content: 'Childhood Cancer Clinical Data Commons',
+      link: '/local',
+      img: 'local-wheel',
+      mobile: 'local-mobile',
+    },
+  ],
+};
+
+describe('parseLandingMarkdown', () => {
+  it('should parse YAML front matter and resolve {{C3DC}}', () => {
+    const parsed = parseLandingMarkdown(sampleLandingMarkdownRaw);
+    expect(parsed).not.toBeNull();
+    expect(parsed.heroTitle).toBe('Discover CCDI Resources');
+    expect(parsed.resourcesApplications[0].link).toBe('https://c3dc.test.example/');
+    expect(parsed.carousel[0].link).toBe('https://c3dc.test.example');
+  });
+
+  it('should return null for empty front matter', () => {
+    expect(parseLandingMarkdown(sampleLandingMarkdownEmpty)).toBeNull();
+  });
+
+  it('should return null for blank input', () => {
+    expect(parseLandingMarkdown('')).toBeNull();
+    expect(parseLandingMarkdown(null)).toBeNull();
+  });
+});
+
+describe('mergeLandingContent', () => {
+  it('should keep defaults when parsed is null', () => {
+    expect(mergeLandingContent(null, defaults)).toBe(defaults);
+  });
+
+  it('should overlay remote fields and keep local images by id', () => {
+    const parsed = parseLandingMarkdown(sampleLandingMarkdownRaw);
+    const merged = mergeLandingContent(parsed, defaults);
+    expect(merged.introData.introTitle1).toBe('Discover CCDI Resources');
+    expect(merged.resourcesAppliationsListData[0].img).toBe('local-img');
+    expect(merged.resourcesAppliationsListData[0].link).toBe(
+      'https://c3dc.test.example/',
+    );
+    expect(merged.carouselList[0].img).toBe('local-wheel');
+    expect(merged.carouselList[0].link).toBe('https://c3dc.test.example');
+  });
+});

--- a/tests/pages/landing/parseLandingMarkdown.test.js
+++ b/tests/pages/landing/parseLandingMarkdown.test.js
@@ -74,8 +74,12 @@ describe('parseLandingMarkdown', () => {
 });
 
 describe('mergeLandingContent', () => {
-  it('should keep defaults when parsed is null', () => {
-    expect(mergeLandingContent(null, defaults)).toBe(defaults);
+  it('should return empty content when parsed is null (no JS copy fallback)', () => {
+    const merged = mergeLandingContent(null, defaults);
+    expect(merged.introData.introTitle1).toBe('');
+    expect(merged.statsData).toEqual([]);
+    expect(merged.resourcesAppliationsListData).toEqual([]);
+    expect(merged.carouselList).toEqual([]);
   });
 
   it('should overlay remote fields and keep local images by id', () => {

--- a/tests/utils/resolveContentTokens.test.js
+++ b/tests/utils/resolveContentTokens.test.js
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for resolveContentTokens ({{C3DC}} substitution).
+ */
+
+jest.mock('../../src/utils/env', () => ({
+  __esModule: true,
+  default: {
+    REACT_APP_C3DC: 'https://c3dc.test.example',
+  },
+}));
+
+import resolveContentTokens, {
+  resolveContentTokenString,
+} from '../../src/utils/resolveContentTokens';
+
+describe('resolveContentTokens', () => {
+  it('should replace {{C3DC}} in a string', () => {
+    expect(resolveContentTokenString('{{C3DC}}/explore')).toBe(
+      'https://c3dc.test.example/explore',
+    );
+  });
+
+  it('should allow whitespace inside the token', () => {
+    expect(resolveContentTokenString('{{ C3DC }}/')).toBe(
+      'https://c3dc.test.example/',
+    );
+  });
+
+  it('should deep-replace tokens in objects and arrays', () => {
+    const input = {
+      link: '{{C3DC}}/',
+      items: [{ href: '{{C3DC}}/studies' }],
+    };
+    expect(resolveContentTokens(input)).toEqual({
+      link: 'https://c3dc.test.example/',
+      items: [{ href: 'https://c3dc.test.example/studies' }],
+    });
+  });
+
+  it('should leave non-string values unchanged', () => {
+    expect(resolveContentTokens(42)).toBe(42);
+    expect(resolveContentTokens(null)).toBe(null);
+  });
+});


### PR DESCRIPTION
Title: PORTAL-2877: Load homepage and nav from remote Markdown

Summary
Decouple Hub homepage and primary navigation copy into remote YAML-in-Markdown (landingData.md, navData.md) under CCDI_Hub_Static_Contents, fetched at runtime from REACT_APP_STATIC_CONTENT_URL.
Add parsers (parseLandingMarkdown, parseNavMarkdown), {{C3DC}} token resolution, and React providers (LandingContentProvider, NavContentProvider) so the landing page and header consume remote content.
No JS copy fallback — if remote MD is missing, invalid, or the request fails, homepage/nav content stays empty until valid remote content loads. Local image assets can still attach by id / carousel content when img / mobile are omitted.
Harden carousel / mobile hero rotation so empty lists do not throw removeChild errors while content is loading.
Document the format, tokens, deploy flow, and failure behavior in docs/static-content.md; add fixtures and unit tests for parsers, controllers, and context.
Test plan

 Confirm REACT_APP_STATIC_CONTENT_URL points at the correct CCDI_Hub_Static_Contents branch

 Host valid landingData.md and navData.md on that branch, then hard-refresh Hub home

 Verify hero text, section titles, stats labels, resource cards, and carousel labels/links

 Verify primary nav + Resources / About submenus (including nested About sections and external C3DC links)

 Confirm {{C3DC}} links resolve to the env’s REACT_APP_C3DC base

 Temporarily break or remove remote MD and confirm homepage/nav stay empty (no bundled JS copy)

 Confirm carousel/mobile hero do not throw when the list is empty

 Run landing/nav unit tests (parseLandingMarkdown, parseNavMarkdown, landingController, NavContentContext, carousel/heroMobile)