### PR TITLE
Add Rare Cancer Resource Page with Markdown Parsing and Navigation

### DIFF
--- a/docs/static-content.md
+++ b/docs/static-content.md
@@ -132,6 +132,44 @@ Each news item:
 
 - `tests/fixtures/news/newsMarkdownSamples.js`
 
+## `rareCancerData.md` (Pediatric, Adolescent, and Young Adult Rare Cancer Study)
+
+| Item | Value |
+|------|--------|
+| Path | `${REACT_APP_STATIC_CONTENT_URL}/rareCancerData.md?ts=<timestamp>` |
+| Hub route | `/pediatric-adolescent-and-young-adult-rare-cancer-study` |
+| Format | YAML front matter + Markdown body (`##` / `###` / `####` + property-table ids) |
+
+### Fields
+
+| Key | Notes |
+|-----|--------|
+| `title` | Page banner title |
+| `RCI_Header` | Absolute URL for the hero banner background (bundled header used if omitted) |
+| `RCI_Data_Flow_Chart_URL` | Absolute URL for the data-flow image (bundled chart used if omitted) |
+| `RCI_DOWNLOAD_CONFIG` | `{ url, filename }` for the contact-form PDF download |
+| `navTitles[]` | Left-nav labels; must match `##` / `###` heading text exactly |
+
+Intro Markdown lives in the body **before the first `##`**. An optional `![RCI data flow chart](<url>)` image is stripped from the intro (the page renders the chart once from `RCI_Data_Flow_Chart_URL`). Nested `####` question headings stay in the subtopic body.
+
+Property tables set scroll/nav ids:
+
+```markdown
+| Property | Value |
+| --- | --- |
+| id | Rare_Cancer_Study_Introduction |
+```
+
+Known ids: topic `Rare_Cancer_Study_Introduction`; subtopics `HOW_TO_ACCESS_STUDY_DATA`, `GERMLINE_FINDINGS`, `CONTACT_INFORMATION`.
+
+### Failure behavior
+
+If the file is missing, YAML is invalid, or the request fails, the Rare Cancer page stays empty until valid remote MD loads (no `resourceData.yaml` fallback).
+
+### Seed fixture
+
+- `tests/fixtures/resource/rareCancerMarkdownSamples.js`
+
 # Static content updates (homepage & navigation)
 
 Hub homepage and primary navigation copy can be updated **without a portal code release** by editing YAML inside markdown files hosted in [`CBIIT/CCDI_Hub_Static_Contents`](https://github.com/CBIIT/CCDI_Hub_Static_Contents).
@@ -248,3 +286,4 @@ Copy-starting samples (for tests and for seeding the static-contents repo):
 - `tests/fixtures/about/aboutSearchMarkdownSamples.js`
 - `tests/fixtures/about/aboutSearchContent.json`
 - `tests/fixtures/news/newsMarkdownSamples.js`
+- `tests/fixtures/resource/rareCancerMarkdownSamples.js`

--- a/src/pages/resource/RareCancerResourcePage/RareCancerMarkdown.js
+++ b/src/pages/resource/RareCancerResourcePage/RareCancerMarkdown.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+function isExternal(href) {
+  if (!href) {
+    return false;
+  }
+  return href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//');
+}
+
+const RareCancerMarkdown = ({ children }) => {
+  if (children === undefined || children === null || children === '') {
+    return null;
+  }
+
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={{
+        a: ({ node: _a, children: linkChildren, href, ...rest }) => {
+          const external = isExternal(href);
+          const mailto = href && href.startsWith('mailto:');
+          return (
+            <a
+              {...rest}
+              href={href}
+              className={external || mailto ? 'link' : undefined}
+              target={external || mailto ? '_blank' : undefined}
+              rel="noopener noreferrer"
+            >
+              {linkChildren}
+            </a>
+          );
+        },
+      }}
+    >
+      {String(children)}
+    </ReactMarkdown>
+  );
+};
+
+export default RareCancerMarkdown;

--- a/src/pages/resource/RareCancerResourcePage/RareCancerResourceController.js
+++ b/src/pages/resource/RareCancerResourcePage/RareCancerResourceController.js
@@ -1,33 +1,44 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect } from 'react';
 import env from '../../../utils/env';
-import yaml from "js-yaml";
-import axios from "axios";
-import RareCancerResourceView from "./RareCancerResourceView";
+import axios from 'axios';
+import parseRareCancerMarkdown from './parseRareCancerMarkdown';
+import RareCancerResourceView from './RareCancerResourceView';
 
-const RESOURCE_URL = env.REACT_APP_STATIC_CONTENT_URL + '/resourceData.yaml';
+const RARE_CANCER_MD_URL = `${env.REACT_APP_STATIC_CONTENT_URL}/rareCancerData.md`;
 
-const RareCancerResourceController = ({ match }) => {
-  const [data, setData] = useState([]);
+const RareCancerResourceController = () => {
+  const [data, setData] = useState({});
 
   useEffect(() => {
     const fetchData = async () => {
-      let resultData = [];
-      let result = [];
+      let resultData = {};
       try {
-        const fileUrl = `${RESOURCE_URL}?ts=${new Date().getTime()}`;
-        result = await axios.get(
-          fileUrl
-        );
-        resultData = yaml.safeLoad(result.data);
+        const fileUrl = `${RARE_CANCER_MD_URL}?ts=${new Date().getTime()}`;
+        const result = await axios.get(fileUrl);
+        resultData = parseRareCancerMarkdown(result.data);
       } catch (_error) {
-        // result = await axios.get(YAMLData);
-        // resultData = yaml.safeLoad(result.data);
+        /* empty state; page still mounts */
       }
-
       setData(resultData);
     };
     fetchData();
   }, []);
-  return <RareCancerResourceView data={data} />;
+
+  useEffect(() => {
+    if (!data.title) {
+      return undefined;
+    }
+    const previousTitle = document.title;
+    document.title = data.title;
+    return () => {
+      document.title = previousTitle;
+    };
+  }, [data.title]);
+
+  if (data.rareCancerContent) {
+    return <RareCancerResourceView data={data} />;
+  }
+  return <div />;
 };
+
 export default RareCancerResourceController;

--- a/src/pages/resource/RareCancerResourcePage/RareCancerResourceView.js
+++ b/src/pages/resource/RareCancerResourcePage/RareCancerResourceView.js
@@ -1,9 +1,7 @@
 import React, { useState, useEffect, useRef, createRef } from 'react';
 import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
-import ReactHtmlParser from 'html-react-parser';
 import { NavLink } from 'react-router-dom';
-// import { MCIContent, introText } from '../../../bento/mciData';
 import headerImg from '../../../assets/resources/Rare_Cancer_Header.png';
 import exportIcon from '../../../assets/resources/Explore_Icon.svg';
 import exportIconBlue from '../../../assets/icons/Export_Icon.svg';
@@ -11,7 +9,9 @@ import closeIcon from '../../../assets/icons/Close_Icon.svg';
 import arrowDownIcon from '../../../assets/icons/Arrow_Down.svg';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import GetAppIcon from '@material-ui/icons/GetApp';
-import introImg from '../../../assets/resources/RCI_data_flow_chart.png'
+import introImg from '../../../assets/resources/RCI_data_flow_chart.png';
+import RareCancerMarkdown from './RareCancerMarkdown';
+import { buildRareCancerNavItems } from './parseRareCancerMarkdown';
 
 const ResourceContainer = styled.div`
     width: 100%;
@@ -52,7 +52,8 @@ const ResourceContainer = styled.div`
     .resourceHeaderBackground {
         width: 100%;
         height: 214px;
-        background-image: url(${props => props.headerImg || headerImg});
+        /* Quote the URL so https:// is not treated as a CSS // comment. */
+        background-image: url(${props => JSON.stringify(props.headerImg || headerImg)});
         background-repeat:no-repeat;
         background-position:center;
     }
@@ -486,23 +487,36 @@ const ContactFormDownloadButton = styled.button`
     }
 `;
 
+const DEFAULT_PAGE_TITLE = 'Pediatric, Adolescent, and Young Adult Rare Cancer Study';
+
 const DEFAULT_DOWNLOAD_CONFIG = {
   url: 'https://raw.githubusercontent.com/CBIIT/CCDI_Hub_Assets/main/PDF/Resources/RCI/rare-cancer-study_contact.pdf',
   filename: 'rare-cancer-study_contact.pdf',
 };
 
-/** Splits HTML after the first </p> so a control can be inserted between paragraphs. */
-function splitHtmlAfterFirstClosingP(html) {
-  if (!html || typeof html !== 'string') {
+/** Splits markdown after the first prose paragraph so the contact-form button can sit between paragraphs. */
+function splitMarkdownAfterFirstParagraph(markdown) {
+  if (!markdown || typeof markdown !== 'string') {
     return { before: '', after: '' };
   }
-  const lower = html.toLowerCase();
-  const idx = lower.indexOf('</p>');
-  if (idx === -1) {
-    return { before: html, after: '' };
+  const lines = markdown.split('\n');
+  let i = 0;
+  while (i < lines.length && !lines[i].trim()) {
+    i += 1;
   }
-  const end = idx + '</p>'.length;
-  return { before: html.slice(0, end), after: html.slice(end) };
+  while (i < lines.length && /^#{1,6}\s/.test(lines[i].trim())) {
+    i += 1;
+    while (i < lines.length && !lines[i].trim()) {
+      i += 1;
+    }
+  }
+  while (i < lines.length && lines[i].trim()) {
+    i += 1;
+  }
+  return {
+    before: lines.slice(0, i).join('\n').trim(),
+    after: lines.slice(i).join('\n').trim(),
+  };
 }
 
 async function handleContactFormDownload(e, config) {
@@ -546,16 +560,16 @@ async function handleContactFormDownload(e, config) {
   }
 }
 
-function ContactInformationContent({ htmlContent }) {
-  const { before, after } = splitHtmlAfterFirstClosingP(htmlContent);
+function ContactInformationContent({ markdown, downloadConfig }) {
+  const { before, after } = splitMarkdownAfterFirstParagraph(markdown);
   return (
     <>
-      <ResourceContent htmlContent={before} />
+      {before ? <RareCancerMarkdown>{before}</RareCancerMarkdown> : null}
       <ContactFormDownloadButtonWrap>
         <ContactFormDownloadButton
           type="button"
           aria-label="Download contact form PDF"
-          onClick={(e) => handleContactFormDownload(e, DEFAULT_DOWNLOAD_CONFIG)}
+          onClick={(e) => handleContactFormDownload(e, downloadConfig)}
         >
           <span className="contactFormDownloadButtonText">
             <span>DOWNLOAD</span>
@@ -564,41 +578,20 @@ function ContactInformationContent({ htmlContent }) {
           <GetAppIcon className="contactFormDownloadIcon" aria-hidden />
         </ContactFormDownloadButton>
       </ContactFormDownloadButtonWrap>
-      {after ? <ResourceContent htmlContent={after} /> : null}
+      {after ? <RareCancerMarkdown>{after}</RareCancerMarkdown> : null}
     </>
   );
 }
 
-function ResourceContent({ htmlContent, downloadConfig }) {
-  const containerRef = useRef(null);
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-    const config = downloadConfig || DEFAULT_DOWNLOAD_CONFIG;
-    const handler = (e) => handleContactFormDownload(e, config);
-    const links = container.querySelectorAll('[data-action="download-contact-form"]');
-    links.forEach((el) => {
-      el.addEventListener('click', handler);
-    });
-    return () => {
-      links.forEach((el) => {
-        el.removeEventListener('click', handler);
-      });
-    };
-  }, [htmlContent, downloadConfig]);
-  return (
-    <div ref={containerRef}>
-      {ReactHtmlParser(htmlContent)}
-    </div>
-  );
-}
-
-const RareCancerResourceView = ({data}) => {
+const RareCancerResourceView = ({ data = {} }) => {
     const [selectedNavTitle, setSelectedNavTitle] = useState('');
     const [stickyNavStyle, setStickyNavStyle] = useState('navList');
     const sectionList = useRef([]);
     const location = useLocation();
     const MCIContent = data.rareCancerContent;
+    const navItems = buildRareCancerNavItems(data.navTitles, MCIContent);
+    const pageTitle = data.title || DEFAULT_PAGE_TITLE;
+    const downloadConfig = data.RCI_DOWNLOAD_CONFIG || DEFAULT_DOWNLOAD_CONFIG;
     if (MCIContent) {
         sectionList.current = MCIContent.map((element, i) => {
             return sectionList.current[i] || createRef()
@@ -639,15 +632,16 @@ const RareCancerResourceView = ({data}) => {
         };
     }, []);
 
-    // Scroll to hash anchor when data is loaded (YAML is async)
+    // Scroll to hash anchor when data is loaded (markdown is async)
     useEffect(() => {
-        const hash = location.hash ? location.hash.slice(1).toUpperCase() : null;
-        if (!hash || !MCIContent) return;
+        const rawHash = location.hash ? location.hash.slice(1) : null;
+        if (!rawHash || !MCIContent) return;
 
         const scrollToAnchor = () => {
-            const element = document.getElementById(hash);  
+            const element = document.getElementById(rawHash)
+                || document.getElementById(rawHash.toUpperCase());
             if (element) {
-                setSelectedNavTitle(hash);
+                setSelectedNavTitle(element.id);
                 window.scrollTo({
                     top: element.offsetTop - 55,
                     behavior: 'smooth'
@@ -665,6 +659,9 @@ const RareCancerResourceView = ({data}) => {
         const id = event.target.getAttribute('name');
         setSelectedNavTitle(id);
         const element = document.getElementById(id);
+        if (!element) {
+            return;
+        }
         window.scrollTo({ 
             top: element.offsetTop - 55,
             behavior: "smooth" 
@@ -697,7 +694,7 @@ const RareCancerResourceView = ({data}) => {
             </div>
             <div className='resourceTitleContainer'>
                 <div className='resourceTitle'>
-                    <div className='resourceTitleText'>Pediatric, Adolescent, and Young Adult Rare Cancer Study</div>
+                    <div className='resourceTitleText'>{pageTitle}</div>
                 </div>
             </div>
             <ResourceBody id='MCIBody'>
@@ -705,30 +702,21 @@ const RareCancerResourceView = ({data}) => {
                     <div className={stickyNavStyle} id='leftNav'>
                         <div className='navTitle'>TOPICS</div>
                         {
-                            MCIContent && MCIContent.map((mci, topicid) => {
-                                const topickey = `topic_${topicid}`;
+                            navItems.map((navItem, navIdx) => {
+                                const navKey = `nav_${navIdx}`;
+                                const className = navItem.isSubtitle
+                                    ? (selectedNavTitle === navItem.id ? 'navTopicItem selected subtitle' : 'navTopicItem subtitle')
+                                    : (selectedNavTitle === navItem.id ? 'navTopicItem selected' : 'navTopicItem');
                                 return (
-                                    <>
-                                        <div name={mci.id} className={selectedNavTitle === mci.id ? 'navTopicItem selected' : 'navTopicItem'} key={topickey} onClick={handleClickEvent}>{mci.topic}</div>
-                                        <div>
-                                            {
-                                                mci.list.map((mciItem, idx) => {
-                                                    const listItemKey = `listItem_${idx}`;
-                                                        return (
-                                                            <div name={mciItem.id} className={selectedNavTitle === mciItem.id ? 'navTopicItem selected subtitle' : 'navTopicItem subtitle'} key={listItemKey} onClick={handleClickEvent}>{mciItem.subtopic}</div>
-                                                        )
-                                                })
-                                            }
-                                        </div>
-                                    </>
-                                )
+                                    <div name={navItem.id} className={className} key={navKey} onClick={handleClickEvent}>{navItem.label}</div>
+                                );
                             })
                         }
                     </div>
                 </div>
                 <div className='contentSection'>
                     <div className='contentList'>
-                        {data.rareCancerIntroText && <div className='introContainer'><ResourceContent htmlContent={data.rareCancerIntroText} downloadConfig={data.RCI_DOWNLOAD_CONFIG} /></div>}
+                        {data.rareCancerIntroText && <div className='introContainer'><RareCancerMarkdown>{data.rareCancerIntroText}</RareCancerMarkdown></div>}
                         <div style={{ justifyContent: 'center', display: 'flex'}}>
                             <img className="introImg" src={data.RCI_Data_Flow_Chart_URL || introImg} alt="RCI data flow" />
                         </div>
@@ -742,20 +730,21 @@ const RareCancerResourceView = ({data}) => {
                                         <div className="mciSection mobileCollapse" ref={sectionList.current[mciidx]}>
                                         {
                                             mci.list.map((mciItem, idx) => {
+                                                const listItemKey = `listItem_${mciidx}_${idx}`;
                                                 return (
-                                                    <>
+                                                    <div key={listItemKey}>
                                                         <div id={mciItem.id} className='mciSubtitle'>{mciItem.subtopic && mciItem.subtopic}</div>
                                                         <div className='mciContentContainer'>
                                                             {mciItem.content && (
                                                                 mciItem.id === 'CONTACT_INFORMATION' ? (
-                                                                    <ContactInformationContent htmlContent={mciItem.content} />
+                                                                    <ContactInformationContent markdown={mciItem.content} downloadConfig={downloadConfig} />
                                                                 ) : (
-                                                                    <ResourceContent htmlContent={mciItem.content} />
+                                                                    <RareCancerMarkdown>{mciItem.content}</RareCancerMarkdown>
                                                                 )
                                                             )}
                                                         </div>
                                                         {mciItem.content && <div style={{height: '40px'}} />}
-                                                    </>
+                                                    </div>
                                                 )
                                             })
                                         }

--- a/src/pages/resource/RareCancerResourcePage/parseRareCancerMarkdown.js
+++ b/src/pages/resource/RareCancerResourcePage/parseRareCancerMarkdown.js
@@ -1,0 +1,362 @@
+import matter from 'gray-matter';
+import {
+  buildNavTitleSet,
+  normalizeNavTitleKey,
+  resolveShowInNav,
+} from '../MCIResourcePage/parseMciMarkdown';
+
+function stripMarkdownHeadingBraceId(rawHeadingInner) {
+  return String(rawHeadingInner || '')
+    .trim()
+    .replace(/\s*\{#[^}]+\}\s*$/, '')
+    .trim();
+}
+
+function slugifyHeadingId(text) {
+  const s = stripMarkdownHeadingBraceId(text)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return (s || 'section').slice(0, 120);
+}
+
+function parseHeadingLine(line, level) {
+  const re = level === 2 ? /^##\s+(.+)$/ : /^###\s+(.+)$/;
+  const m = line.match(re);
+  if (!m) return null;
+  const rawInner = m[1];
+  const title = stripMarkdownHeadingBraceId(rawInner);
+  return { title, id: slugifyHeadingId(rawInner) };
+}
+
+function firstDefined(...values) {
+  for (let i = 0; i < values.length; i += 1) {
+    const v = values[i];
+    if (v !== undefined && v !== null) {
+      return v;
+    }
+  }
+  return undefined;
+}
+
+function trimMd(s) {
+  return String(s || '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function parseMarkdownTable(tableLines) {
+  const meta = {};
+  tableLines.forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('|') || /^\|\s*---/.test(trimmed) || /^\|\s*Property\s*\|/i.test(trimmed)) {
+      return;
+    }
+    const cells = trimmed
+      .replace(/^\|/, '')
+      .replace(/\|$/, '')
+      .split('|')
+      .map((c) => c.trim());
+    if (cells.length >= 2 && cells[0]) {
+      meta[cells[0]] = cells[1];
+    }
+  });
+  return meta;
+}
+
+function extractLeadingPropertyTable(body) {
+  const lines = String(body || '').split('\n');
+  let i = 0;
+  while (i < lines.length && !lines[i].trim()) {
+    i += 1;
+  }
+  if (i >= lines.length || !/^\|\s*Property\s*\|\s*Value\s*\|/i.test(lines[i].trim())) {
+    return { content: String(body || '').trim(), meta: {} };
+  }
+  const tableStart = i;
+  let tableEnd = tableStart + 1;
+  while (tableEnd < lines.length && lines[tableEnd].trim().startsWith('|')) {
+    tableEnd += 1;
+  }
+  const meta = parseMarkdownTable(lines.slice(tableStart, tableEnd));
+  const content = [...lines.slice(0, tableStart), ...lines.slice(tableEnd)].join('\n').trim();
+  return { content, meta };
+}
+
+function splitTrailingPropertyTable(body) {
+  const lines = String(body || '').split('\n');
+  let tableStart = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (/^\|\s*Property\s*\|\s*Value\s*\|/i.test(lines[i].trim())) {
+      tableStart = i;
+    }
+  }
+  if (tableStart < 0) {
+    return { content: String(body || '').trim(), meta: {} };
+  }
+  const content = lines.slice(0, tableStart).join('\n').trim();
+  const meta = parseMarkdownTable(lines.slice(tableStart));
+  return { content, meta };
+}
+
+function extractIntroAndRest(body) {
+  if (!body || !String(body).trim()) {
+    return { intro: '', rest: '' };
+  }
+  const lines = body.split('\n');
+  let introEnd = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (/^##\s/.test(lines[i])) {
+      introEnd = i;
+      break;
+    }
+  }
+  if (introEnd === -1) {
+    return { intro: body.trim(), rest: '' };
+  }
+  return {
+    intro: lines.slice(0, introEnd).join('\n').trim(),
+    rest: lines.slice(introEnd).join('\n'),
+  };
+}
+
+/**
+ * Removes the dedicated flow-chart image from intro markdown so the view can
+ * render it once from RCI_Data_Flow_Chart_URL (with a bundled fallback).
+ */
+export function stripIntroFlowChart(intro, fmUrl) {
+  const imgRe = /!\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+  let extractedUrl = '';
+  const cleaned = String(intro || '').replace(imgRe, (full, url) => {
+    const alt = (full.match(/^!\[([^\]]*)\]/) || [])[1] || '';
+    if (/flow\s*chart/i.test(alt) || (fmUrl && url === fmUrl)) {
+      extractedUrl = url;
+      return '';
+    }
+    return full;
+  });
+  return { intro: trimMd(cleaned), extractedUrl };
+}
+
+function splitH2(rest) {
+  if (!rest || !rest.trim()) return [];
+  const lines = rest.split('\n');
+  const topics = [];
+  let cur = null;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^##\s/.test(line)) {
+      if (cur) {
+        topics.push({
+          topic: cur.title,
+          id: cur.id,
+          body: cur.lines.join('\n').trim(),
+        });
+      }
+      const p = parseHeadingLine(line, 2);
+      const rawH2 = line.replace(/^##\s+/, '').trim();
+      cur = p
+        ? { title: p.title, id: p.id, lines: [] }
+        : {
+            title: stripMarkdownHeadingBraceId(rawH2),
+            id: slugifyHeadingId(rawH2),
+            lines: [],
+          };
+    } else if (cur) {
+      cur.lines.push(line);
+    }
+  }
+  if (cur) {
+    topics.push({
+      topic: cur.title,
+      id: cur.id,
+      body: cur.lines.join('\n').trim(),
+    });
+  }
+  return topics;
+}
+
+function pushH3Sub(subs, cur) {
+  subs.push({
+    subtopic: cur.subtopic,
+    id: cur.id,
+    body: cur.lines.join('\n'),
+  });
+}
+
+function splitH3InTopic(topicBody) {
+  if (!topicBody || !topicBody.trim()) return [];
+  const lines = topicBody.split('\n');
+  const subs = [];
+  let cur = null;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^###\s/.test(line)) {
+      if (cur) {
+        pushH3Sub(subs, cur);
+      }
+      const p = parseHeadingLine(line, 3);
+      const rawH3 = line.replace(/^###\s+/, '').trim();
+      cur = p
+        ? { subtopic: p.title, id: p.id, lines: [] }
+        : {
+            subtopic: stripMarkdownHeadingBraceId(rawH3),
+            id: slugifyHeadingId(rawH3),
+            lines: [],
+          };
+    } else if (cur) {
+      cur.lines.push(line);
+    }
+  }
+  if (cur) {
+    pushH3Sub(subs, cur);
+  }
+  return subs;
+}
+
+function resolveSectionId(meta, fallbackId) {
+  const fromTable = meta && meta.id != null ? String(meta.id).trim() : '';
+  return fromTable || fallbackId;
+}
+
+/**
+ * Builds ordered side-nav entries from front matter navTitles (topic + subtopics).
+ * Falls back to document order when navTitles is omitted.
+ */
+export function buildRareCancerNavItems(navTitles, rareCancerContent) {
+  const content = Array.isArray(rareCancerContent) ? rareCancerContent : [];
+  if (!Array.isArray(navTitles) || navTitles.length === 0) {
+    const items = [];
+    content.forEach((topic) => {
+      items.push({ id: topic.id, label: topic.topic, isSubtitle: false });
+      (topic.list || []).forEach((sub) => {
+        items.push({ id: sub.id, label: sub.subtopic, isSubtitle: true });
+      });
+    });
+    return items;
+  }
+
+  const topicByKey = new Map();
+  const subByKey = new Map();
+  content.forEach((topic) => {
+    topicByKey.set(normalizeNavTitleKey(topic.topic), topic);
+    (topic.list || []).forEach((sub) => {
+      subByKey.set(normalizeNavTitleKey(sub.subtopic), { topic, sub });
+    });
+  });
+
+  return navTitles
+    .map((title) => {
+      const key = normalizeNavTitleKey(title);
+      const topic = topicByKey.get(key);
+      if (topic) {
+        return { id: topic.id, label: topic.topic, isSubtitle: false };
+      }
+      const subMatch = subByKey.get(key);
+      if (subMatch) {
+        return {
+          id: subMatch.sub.id,
+          label: subMatch.sub.subtopic,
+          isSubtitle: true,
+        };
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+function normalizeDownloadConfig(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return undefined;
+  }
+  const url = raw.url != null ? String(raw.url).trim() : '';
+  const filename = raw.filename != null ? String(raw.filename).trim() : '';
+  if (!url && !filename) {
+    return undefined;
+  }
+  return {
+    url,
+    filename: filename || 'rare-cancer-study_contact.pdf',
+  };
+}
+
+/**
+ * Parses rareCancerData.md (YAML front matter + ## / ### / #### body + property-table ids).
+ * @param {string} rawMarkdown
+ * @returns {{
+ *   title: string,
+ *   RCI_Header: string,
+ *   RCI_Data_Flow_Chart_URL: string,
+ *   RCI_DOWNLOAD_CONFIG: { url: string, filename: string }|undefined,
+ *   rareCancerIntroText: string,
+ *   navTitles: string[]|undefined,
+ *   rareCancerContent: Array<{ id: string, topic: string, list: Array<{ id: string, subtopic: string, content: string }> }>
+ * }}
+ */
+export function parseRareCancerMarkdown(rawMarkdown) {
+  const source = String(rawMarkdown || '').replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
+  const { data: fm, content: body } = matter(source);
+  const {
+    title: fmTitle,
+    RCI_Header: fmHeader,
+    RCI_Data_Flow_Chart_URL: fmFlowChart,
+    RCI_DOWNLOAD_CONFIG: fmDownload,
+    rareCancerIntroText: legacyIntro,
+    navTitles: fmNavTitles,
+    rareCancerNavTitles,
+    nav_titles: fmNavTitlesSnake,
+    ...restFm
+  } = fm;
+
+  const title = String(fmTitle || '').trim();
+  const RCI_Header = String(fmHeader || '').trim();
+  const rawNavTitles = firstDefined(fmNavTitles, rareCancerNavTitles, fmNavTitlesSnake);
+  const navTitleSet = buildNavTitleSet(rawNavTitles);
+  const navTitles = Array.isArray(rawNavTitles) ? rawNavTitles : undefined;
+
+  const { intro: introFromBody, rest } = extractIntroAndRest(body || '');
+  const introRaw =
+    String(introFromBody || '').trim() !== ''
+      ? introFromBody
+      : legacyIntro != null
+        ? String(legacyIntro)
+        : '';
+
+  const fmFlowUrl = String(fmFlowChart || '').trim();
+  const { intro: rareCancerIntroText, extractedUrl } = stripIntroFlowChart(introRaw, fmFlowUrl);
+  const RCI_Data_Flow_Chart_URL = fmFlowUrl || extractedUrl;
+
+  const topics = splitH2(rest);
+  const rareCancerContent = topics.map((t) => {
+    const { content: topicBody, meta: topicMeta } = extractLeadingPropertyTable(t.body);
+    const subs = splitH3InTopic(topicBody);
+    const list = subs.map((s) => {
+      const { content, meta } = splitTrailingPropertyTable(s.body);
+      return {
+        id: resolveSectionId(meta, s.id),
+        subtopic: s.subtopic,
+        showInNav: resolveShowInNav(s.subtopic, navTitleSet),
+        content,
+      };
+    });
+    return {
+      id: resolveSectionId(topicMeta, t.id),
+      topic: t.topic,
+      showInNav: resolveShowInNav(t.topic, navTitleSet),
+      list,
+    };
+  });
+
+  return {
+    ...restFm,
+    title,
+    RCI_Header,
+    RCI_Data_Flow_Chart_URL,
+    RCI_DOWNLOAD_CONFIG: normalizeDownloadConfig(fmDownload),
+    rareCancerIntroText,
+    navTitles,
+    rareCancerContent,
+  };
+}
+
+export default parseRareCancerMarkdown;

--- a/tests/fixtures/resource/rareCancerMarkdownSamples.js
+++ b/tests/fixtures/resource/rareCancerMarkdownSamples.js
@@ -1,0 +1,93 @@
+/**
+ * Sample rareCancerData.md for parseRareCancerMarkdown tests.
+ */
+
+export const sampleRareCancerMarkdownRaw = `---
+title: Pediatric, Adolescent, and Young Adult Rare Cancer Study
+RCI_Header: "https://example.com/rare-cancer-header.png"
+RCI_Data_Flow_Chart_URL: "https://example.com/rci-flow-chart.png"
+RCI_DOWNLOAD_CONFIG:
+  url: "https://example.com/rare-cancer-study_contact.pdf"
+  filename: rare-cancer-study_contact.pdf
+navTitles:
+  - Accessing Pediatric and AYA Rare Cancer Study Data
+  - How to Access Study Data
+  - Germline Findings
+  - Contact Information
+---
+
+The Childhood Cancer Data Initiative (CCDI) Pediatric, Adolescent, and Young Adult Rare Cancer Study is a longitudinal study.
+
+For an overview of this program, [access the study’s web page on cancer.gov](https://www.cancer.gov/research).
+
+![RCI data flow chart](https://example.com/rci-flow-chart.png)
+
+## Accessing Pediatric and AYA Rare Cancer Study Data
+
+| Property | Value |
+| --- | --- |
+| id | Rare_Cancer_Study_Introduction |
+
+### How to Access Study Data
+
+#### How can Pediatric and AYA Rare Cancer Study data be accessed through the CCDI Data Ecosystem?
+
+Study data can be accessed through the CCDI Data Ecosystem.
+
+You can search by the study name. [This user guide](/user-guide.pdf) provides information.
+
+| Property | Value |
+| --- | --- |
+| id | HOW_TO_ACCESS_STUDY_DATA |
+
+### Germline Findings
+
+#### What steps should be taken if germline findings are detected?
+
+The participant’s physician should coordinate a referral for genetic counseling.
+
+| Property | Value |
+| --- | --- |
+| id | GERMLINE_FINDINGS |
+
+### Contact Information
+
+#### Who should I contact with questions about CCDI Pediatric and AYA Rare Cancer Study results and data?
+
+If you are interested in participating, download the contact form.
+
+For questions related to study data, contact [NCIChildhoodCancerDataInitiative@mail.nih.gov](mailto:NCIChildhoodCancerDataInitiative@mail.nih.gov).
+
+| Property | Value |
+| --- | --- |
+| id | CONTACT_INFORMATION |
+`;
+
+export const sampleRareCancerMarkdownNoNavTitles = `---
+title: Rare Cancer Without Nav
+RCI_Header: https://example.com/header.png
+---
+
+Intro only before topics.
+
+## Topic Alpha
+
+### Sub One
+
+Body for sub one.
+`;
+
+export const sampleRareCancerMarkdownFlowChartOnlyInBody = `---
+title: Flow Chart From Body
+---
+
+Lead paragraph.
+
+![RCI data flow chart](https://example.com/from-body-chart.png)
+
+## Topic
+
+### Sub
+
+Body.
+`;

--- a/tests/fixtures/resource/resourceDataViewProps.js
+++ b/tests/fixtures/resource/resourceDataViewProps.js
@@ -1,6 +1,7 @@
 /**
- * Minimal shapes for pages that load `resourceData.yaml` (Group B).
- * Keys match what each *ResourceView reads from YAML-loaded `data`.
+ * Minimal shapes for resource *ResourceView props.
+ * Group B pages historically loaded `resourceData.yaml`; Tools / Federation / Rare Cancer
+ * now consume parsed markdown (`toolsData.md`, `federationData.md`, `rareCancerData.md`).
  */
 
 /** ToolsResourceController requires `toolsContent` to render the view. */
@@ -53,7 +54,9 @@ export const minimalCcdiEventAnnouncementsResourceData = {
 };
 
 export const minimalRareCancerResourceData = {
-  rareCancerIntroText: '<p>Rare cancer intro for unit test.</p>',
+  title: 'Pediatric, Adolescent, and Young Adult Rare Cancer Study',
+  rareCancerIntroText: 'Rare cancer intro for unit test.',
+  navTitles: ['Rare Cancer Topic', 'Rare Subsection'],
   rareCancerContent: [
     {
       id: 'rc_section',
@@ -62,7 +65,7 @@ export const minimalRareCancerResourceData = {
         {
           id: 'rc_sub',
           subtopic: 'Rare Subsection',
-          content: '<p>Rare cancer subsection body.</p>',
+          content: 'Rare cancer subsection body.',
         },
       ],
     },

--- a/tests/fixtures/resource/resourceInteractionData.js
+++ b/tests/fixtures/resource/resourceInteractionData.js
@@ -83,16 +83,17 @@ export const multiTopicPmtlData = {
 
 export const multiTopicRareCancerData = {
   ...minimalRareCancerResourceData,
+  navTitles: ['Rare Topic A', 'Rare Sub A', 'Rare Topic B', 'Rare Sub B'],
   rareCancerContent: [
     {
       id: 'RC_SECTION',
       topic: 'Rare Topic A',
-      list: [{ id: 'rc_sub_a', subtopic: 'Rare Sub A', content: '<p>Rare A</p>' }],
+      list: [{ id: 'rc_sub_a', subtopic: 'Rare Sub A', content: 'Rare A' }],
     },
     {
       id: 'rc_b',
       topic: 'Rare Topic B',
-      list: [{ id: 'rc_sub_b', subtopic: 'Rare Sub B', content: '<p>Rare B</p>' }],
+      list: [{ id: 'rc_sub_b', subtopic: 'Rare Sub B', content: 'Rare B' }],
     },
   ],
 };
@@ -100,28 +101,27 @@ export const multiTopicRareCancerData = {
 /** Same-origin contact-form download + custom flow-chart URL. */
 export const rareCancerWithDownloadData = {
   ...minimalRareCancerResourceData,
-  rareCancerIntroText:
-    '<p>Rare cancer intro with download.</p>'
-    + '<a href="#" data-action="download-contact-form">Download contact form</a>',
+  rareCancerIntroText: 'Rare cancer intro with download.',
   RCI_DOWNLOAD_CONFIG: {
     url: '/local/rare-cancer-contact.pdf',
     filename: 'rare-cancer-contact.pdf',
   },
   RCI_Data_Flow_Chart_URL: 'https://example.com/custom-rci-flow-chart.png',
+  navTitles: ['Rare Topic A', 'Contact Information', 'Rare Topic B', 'Rare Sub B'],
   rareCancerContent: [
     {
       id: 'RC_SECTION',
       topic: 'Rare Topic A',
       list: [{
-        id: 'rc_sub_a',
-        subtopic: 'Rare Sub A',
-        content: '<p>Section body <a href="#" data-action="download-contact-form">Section download</a></p>',
+        id: 'CONTACT_INFORMATION',
+        subtopic: 'Contact Information',
+        content: '#### Who should I contact?\n\nIf you are interested in participating, download the contact form.\n\nFor questions related to study data.',
       }],
     },
     {
       id: 'rc_b',
       topic: 'Rare Topic B',
-      list: [{ id: 'rc_sub_b', subtopic: 'Rare Sub B', content: '<p>Rare B</p>' }],
+      list: [{ id: 'rc_sub_b', subtopic: 'Rare Sub B', content: 'Rare B' }],
     },
   ],
 };

--- a/tests/pages/resource/RareCancerResourcePage/parseRareCancerMarkdown.test.js
+++ b/tests/pages/resource/RareCancerResourcePage/parseRareCancerMarkdown.test.js
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for parseRareCancerMarkdown (rareCancerData.md → view props).
+ */
+
+import parseRareCancerMarkdown, {
+  buildRareCancerNavItems,
+  stripIntroFlowChart,
+} from '../../../../src/pages/resource/RareCancerResourcePage/parseRareCancerMarkdown';
+import {
+  sampleRareCancerMarkdownRaw,
+  sampleRareCancerMarkdownNoNavTitles,
+  sampleRareCancerMarkdownFlowChartOnlyInBody,
+} from '../../../fixtures/resource/rareCancerMarkdownSamples';
+
+describe('parseRareCancerMarkdown', () => {
+  it('should parse front matter, intro, topics, subtopics, and property-table ids', () => {
+    const data = parseRareCancerMarkdown(sampleRareCancerMarkdownRaw);
+
+    expect(data.title).toBe('Pediatric, Adolescent, and Young Adult Rare Cancer Study');
+    expect(data.RCI_Header).toBe('https://example.com/rare-cancer-header.png');
+    expect(data.RCI_Data_Flow_Chart_URL).toBe('https://example.com/rci-flow-chart.png');
+    expect(data.RCI_DOWNLOAD_CONFIG).toEqual({
+      url: 'https://example.com/rare-cancer-study_contact.pdf',
+      filename: 'rare-cancer-study_contact.pdf',
+    });
+    expect(data.rareCancerIntroText).toContain('longitudinal study');
+    expect(data.rareCancerIntroText).toContain('cancer.gov');
+    expect(data.rareCancerIntroText).not.toContain('RCI data flow chart');
+    expect(data.navTitles).toHaveLength(4);
+    expect(data.rareCancerContent).toHaveLength(1);
+
+    const topic = data.rareCancerContent[0];
+    expect(topic.id).toBe('Rare_Cancer_Study_Introduction');
+    expect(topic.topic).toBe('Accessing Pediatric and AYA Rare Cancer Study Data');
+    expect(topic.list).toHaveLength(3);
+
+    expect(topic.list[0].id).toBe('HOW_TO_ACCESS_STUDY_DATA');
+    expect(topic.list[0].subtopic).toBe('How to Access Study Data');
+    expect(topic.list[0].content).toContain('#### How can Pediatric and AYA Rare Cancer Study data');
+    expect(topic.list[0].content).toContain('CCDI Data Ecosystem');
+    expect(topic.list[0].content).not.toContain('| id |');
+
+    expect(topic.list[1].id).toBe('GERMLINE_FINDINGS');
+    expect(topic.list[1].subtopic).toBe('Germline Findings');
+
+    expect(topic.list[2].id).toBe('CONTACT_INFORMATION');
+    expect(topic.list[2].subtopic).toBe('Contact Information');
+    expect(topic.list[2].content).toContain('mailto:NCIChildhoodCancerDataInitiative@mail.nih.gov');
+  });
+
+  it('should build side nav from navTitles in order using property-table ids', () => {
+    const data = parseRareCancerMarkdown(sampleRareCancerMarkdownRaw);
+    const navItems = buildRareCancerNavItems(data.navTitles, data.rareCancerContent);
+
+    expect(navItems).toHaveLength(4);
+    expect(navItems.map((item) => item.label)).toEqual([
+      'Accessing Pediatric and AYA Rare Cancer Study Data',
+      'How to Access Study Data',
+      'Germline Findings',
+      'Contact Information',
+    ]);
+    expect(navItems.map((item) => item.id)).toEqual([
+      'Rare_Cancer_Study_Introduction',
+      'HOW_TO_ACCESS_STUDY_DATA',
+      'GERMLINE_FINDINGS',
+      'CONTACT_INFORMATION',
+    ]);
+    expect(navItems[0].isSubtitle).toBe(false);
+    expect(navItems[1].isSubtitle).toBe(true);
+  });
+
+  it('should fall back to document order when navTitles is omitted', () => {
+    const data = parseRareCancerMarkdown(sampleRareCancerMarkdownNoNavTitles);
+    const navItems = buildRareCancerNavItems(data.navTitles, data.rareCancerContent);
+
+    expect(navItems).toHaveLength(2);
+    expect(navItems[0].label).toBe('Topic Alpha');
+    expect(navItems[1].label).toBe('Sub One');
+    expect(navItems[0].isSubtitle).toBe(false);
+    expect(navItems[1].isSubtitle).toBe(true);
+  });
+
+  it('should take flow-chart URL from intro image when front matter omits it', () => {
+    const data = parseRareCancerMarkdown(sampleRareCancerMarkdownFlowChartOnlyInBody);
+    expect(data.RCI_Data_Flow_Chart_URL).toBe('https://example.com/from-body-chart.png');
+    expect(data.rareCancerIntroText).toBe('Lead paragraph.');
+  });
+
+  it('should handle empty input and strip BOM', () => {
+    expect(parseRareCancerMarkdown('')).toEqual({
+      title: '',
+      RCI_Header: '',
+      RCI_Data_Flow_Chart_URL: '',
+      RCI_DOWNLOAD_CONFIG: undefined,
+      rareCancerIntroText: '',
+      navTitles: undefined,
+      rareCancerContent: [],
+    });
+
+    const bom = `\uFEFF---\ntitle: BOM Rare Cancer\nRCI_Header: https://example.com/bom.png\n---\n\nIntro.\n\n## Topic\n\n### Sub\n\nBody.\n`;
+    const parsed = parseRareCancerMarkdown(bom);
+    expect(parsed.title).toBe('BOM Rare Cancer');
+    expect(parsed.rareCancerContent[0].list[0].content).toBe('Body.');
+  });
+});
+
+describe('stripIntroFlowChart', () => {
+  it('should remove a flow-chart image and keep surrounding prose', () => {
+    const { intro, extractedUrl } = stripIntroFlowChart(
+      'Before.\n\n![RCI data flow chart](https://example.com/chart.png)\n\nAfter.',
+      '',
+    );
+    expect(intro).toBe('Before.\n\nAfter.');
+    expect(extractedUrl).toBe('https://example.com/chart.png');
+  });
+});

--- a/tests/pages/resource/RareCancerResourcePage/rareCancerResourceController.test.js
+++ b/tests/pages/resource/RareCancerResourcePage/rareCancerResourceController.test.js
@@ -1,70 +1,110 @@
 /**
- * RareCancerResourceController — mocked axios GET for `resourceData.yaml`.
+ * RareCancerResourceController — fetches rareCancerData.md, parses markdown, renders view.
  *
- * Follows tests/TEST_STRUCTURE.md controller pattern (mock env/axios, waitFor, assert URL + DOM from fixtures).
+ * @see src/pages/resource/RareCancerResourcePage/RareCancerResourceController.js
  */
-
-import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
-import { render, screen, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import axios from 'axios';
-import RareCancerResourceController from '../../../../src/pages/resource/RareCancerResourcePage/RareCancerResourceController';
-import { minimalRareCancerResourceData } from '../../../fixtures/resource/resourceDataViewProps';
-import { createDedicatedYamlAxiosMock } from '../../../helpers/resourceYamlApiMocks';
-
-if (typeof global.MutationObserver === 'undefined') {
-  global.MutationObserver = class MutationObserver {
-    disconnect() {}
-    observe() {}
-    takeRecords() {
-      return [];
-    }
-  };
-}
 
 jest.mock('axios');
 jest.mock('../../../../src/utils/env', () => ({
   REACT_APP_STATIC_CONTENT_URL: 'https://static.example.com',
 }));
 
-beforeEach(() => {
-  window.scrollTo = jest.fn();
-  for (let i = 0; i < 3; i += 1) {
-    document.body.appendChild(document.createElement('footer'));
-  }
-});
+jest.mock('../../../../src/pages/resource/RareCancerResourcePage/parseRareCancerMarkdown', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    title: 'Pediatric, Adolescent, and Young Adult Rare Cancer Study',
+    RCI_Header: 'https://example.com/rare-cancer-header.png',
+    RCI_Data_Flow_Chart_URL: 'https://example.com/rci-flow-chart.png',
+    rareCancerIntroText: 'Rare cancer intro for unit test.',
+    navTitles: ['Rare Cancer Topic', 'Rare Subsection'],
+    rareCancerContent: [
+      {
+        id: 'rc_section',
+        topic: 'Rare Cancer Topic',
+        list: [
+          {
+            id: 'rc_sub',
+            subtopic: 'Rare Subsection',
+            content: 'Rare cancer subsection body.',
+          },
+        ],
+      },
+    ],
+  })),
+}));
 
-afterEach(() => {
+jest.mock('../../../../src/pages/resource/RareCancerResourcePage/RareCancerResourceView', () => (
+  function MockRareCancerResourceView({ data }) {
+    return <div>{data?.rareCancerContent?.[0]?.topic || 'no-content'}</div>;
+  }
+));
+
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import axios from 'axios';
+import parseRareCancerMarkdown from '../../../../src/pages/resource/RareCancerResourcePage/parseRareCancerMarkdown';
+import RareCancerResourceController from '../../../../src/pages/resource/RareCancerResourcePage/RareCancerResourceController';
+
+beforeEach(() => {
   jest.clearAllMocks();
-  document.querySelectorAll('footer').forEach((el) => el.remove());
+  document.title = 'Initial Title';
+  axios.get.mockResolvedValue({ data: 'rare-cancer-markdown' });
+  global.MutationObserver = class {
+    constructor() {
+      this.observe = jest.fn();
+      this.disconnect = jest.fn();
+      this.takeRecords = jest.fn(() => []);
+    }
+  };
 });
 
 describe('RareCancerResourceController', () => {
-  describe('Mocked axios (resourceData.yaml)', () => {
-    it('should fetch resourceData.yaml and render rare cancer content', async () => {
-      axios.get.mockImplementation(
-        createDedicatedYamlAxiosMock({
-          '/resourceData.yaml': minimalRareCancerResourceData,
-        }),
-      );
+  it('should fetch rareCancerData.md and render rare cancer content', async () => {
+    render(
+      <MemoryRouter initialEntries={['/pediatric-adolescent-and-young-adult-rare-cancer-study']}>
+        <RareCancerResourceController />
+      </MemoryRouter>,
+    );
 
-      render(
-        <MemoryRouter initialEntries={['/explore']}>
-          <RareCancerResourceController />
-        </MemoryRouter>,
-      );
-
-      await waitFor(() => {
-        expect(
-          screen.getByText(/Pediatric, Adolescent, and Young Adult Rare Cancer Study/i),
-        ).toBeInTheDocument();
-      });
-
+    await waitFor(() => {
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringMatching(/^https:\/\/static\.example\.com\/resourceData\.yaml\?ts=\d+$/),
+        expect.stringMatching(/^https:\/\/static\.example\.com\/rareCancerData\.md\?ts=\d+$/),
       );
-      expect(screen.getByText(/Rare cancer intro for unit test/i)).toBeInTheDocument();
     });
+    expect(parseRareCancerMarkdown).toHaveBeenCalledWith('rare-cancer-markdown');
+
+    await waitFor(() => {
+      expect(screen.getByText('Rare Cancer Topic')).toBeInTheDocument();
+    });
+  });
+
+  it('should set document title from parsed front matter title', async () => {
+    render(
+      <MemoryRouter initialEntries={['/pediatric-adolescent-and-young-adult-rare-cancer-study']}>
+        <RareCancerResourceController />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(document.title).toBe('Pediatric, Adolescent, and Young Adult Rare Cancer Study');
+    });
+  });
+
+  it('should render an empty div when parsed data has no rareCancerContent', async () => {
+    parseRareCancerMarkdown.mockReturnValueOnce({ title: 'Rare Cancer', rareCancerContent: undefined });
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/pediatric-adolescent-and-young-adult-rare-cancer-study']}>
+        <RareCancerResourceController />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('Rare Cancer Topic')).not.toBeInTheDocument();
+    expect(container.querySelector('div').textContent).toBe('');
   });
 });

--- a/tests/pages/resource/RareCancerResourcePage/rareCancerResourceView.test.js
+++ b/tests/pages/resource/RareCancerResourcePage/rareCancerResourceView.test.js
@@ -1,10 +1,16 @@
 /**
- * Unit tests for RareCancerResourceView (`resourceData.yaml` — rare cancer fields as static props).
+ * Unit tests for RareCancerResourceView (rareCancerData.md parsed props).
  *
  * Structure follows tests/TEST_STRUCTURE.md:
  * Rendering → feature sections → Side effects → Edge cases.
  * Fixtures: tests/fixtures/resource/resourceDataViewProps.js (no network).
  */
+
+jest.mock('../../../../src/pages/resource/RareCancerResourcePage/RareCancerMarkdown', () => (
+  function MockRareCancerMarkdown({ children }) {
+    return <div data-testid="rare-cancer-markdown">{children}</div>;
+  }
+));
 
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -61,6 +67,17 @@ describe('RareCancerResourceView', () => {
       expect(screen.getByText('TOPICS')).toBeInTheDocument();
     });
 
+    it('should apply a quoted remote header URL so https:// is not treated as a CSS comment', () => {
+      renderRareCancerView({
+        ...minimalRareCancerResourceData,
+        RCI_Header: 'https://example.com/rare-cancer-header.png',
+      });
+      const css = Array.from(document.querySelectorAll('style'))
+        .map((el) => el.textContent)
+        .join('\n');
+      expect(css).toContain('url("https://example.com/rare-cancer-header.png")');
+    });
+
     it('should render RCI data flow image with custom URL when provided', () => {
       renderRareCancerView(rareCancerWithDownloadData);
       const img = screen.getByAltText('RCI data flow');
@@ -86,12 +103,20 @@ describe('RareCancerResourceView', () => {
   });
 
   describe('Contact form download', () => {
-    it('should trigger same-origin download when contact link is clicked', () => {
+    it('should insert the contact form button between the first and remaining paragraphs', () => {
+      renderRareCancerView(rareCancerWithDownloadData);
+      const button = screen.getByRole('button', { name: /Download contact form/i });
+      expect(button).toBeInTheDocument();
+      expect(screen.getByText(/If you are interested in participating/i)).toBeInTheDocument();
+      expect(screen.getByText(/For questions related to study data/i)).toBeInTheDocument();
+    });
+
+    it('should trigger same-origin download when contact form button is clicked', () => {
       renderRareCancerView(rareCancerWithDownloadData);
       const appendChildSpy = jest.spyOn(document.body, 'appendChild');
       const removeChildSpy = jest.spyOn(document.body, 'removeChild');
 
-      fireEvent.click(screen.getByText('Download contact form'));
+      fireEvent.click(screen.getByRole('button', { name: /Download contact form/i }));
 
       expect(appendChildSpy).toHaveBeenCalled();
       const appendedLink = appendChildSpy.mock.calls.find(
@@ -114,7 +139,7 @@ describe('RareCancerResourceView', () => {
       renderRareCancerView(rareCancerCrossOriginDownloadData);
       const appendChildSpy = jest.spyOn(document.body, 'appendChild');
 
-      fireEvent.click(screen.getByText('Download contact form'));
+      fireEvent.click(screen.getByRole('button', { name: /Download contact form/i }));
 
       await act(async () => {
         await Promise.resolve();
@@ -137,7 +162,7 @@ describe('RareCancerResourceView', () => {
       renderRareCancerView(malformedDownloadData);
       const appendChildSpy = jest.spyOn(document.body, 'appendChild');
 
-      fireEvent.click(screen.getByText('Download contact form'));
+      fireEvent.click(screen.getByRole('button', { name: /Download contact form/i }));
 
       expect(appendChildSpy).toHaveBeenCalled();
     });
@@ -149,14 +174,14 @@ describe('RareCancerResourceView', () => {
 
       renderRareCancerView(rareCancerCrossOriginDownloadData);
 
-      fireEvent.click(screen.getByText('Section download'));
+      fireEvent.click(screen.getByRole('button', { name: /Download contact form/i }));
 
       await act(async () => {
         await Promise.resolve();
       });
 
       expect(window.open).toHaveBeenCalledWith(
-        'https://raw.githubusercontent.com/CBIIT/CCDI_Hub_Assets/main/PDF/Resources/RCI/rare-cancer-study_contact.pdf',
+        'https://cdn.example.com/rare-cancer-contact.pdf',
         '_blank',
       );
       consoleError.mockRestore();
@@ -325,7 +350,7 @@ describe('RareCancerResourceView', () => {
   describe('Edge cases', () => {
     it('should render when rareCancerContent is missing without throwing', () => {
       expect(() =>
-        renderRareCancerView({ rareCancerIntroText: '<p>Intro only.</p>' }),
+        renderRareCancerView({ rareCancerIntroText: 'Intro only.' }),
       ).not.toThrow();
       expect(screen.getByText(/Intro only/i)).toBeInTheDocument();
     });


### PR DESCRIPTION
- Introduced `rareCancerData.md` for the Pediatric, Adolescent, and Young Adult Rare Cancer Study, detailing structure and content fields.
- Implemented `parseRareCancerMarkdown` to handle parsing of the new markdown format, extracting metadata and content for rendering.
- Created `RareCancerMarkdown` component for rendering parsed markdown content.
- Updated `RareCancerResourceController` to fetch and parse the new markdown file, setting document titles based on parsed data.
- Enhanced `RareCancerResourceView` to display content and manage navigation based on parsed structure.
- Added unit tests for parsing functionality and component rendering.
- Included sample markdown fixtures for testing purposes.