### PR TITLE
Enhance Federation Resource Page with nested subtopic support

### DIFF
--- a/src/pages/resource/FederationResourcePage/FederationResourceView.js
+++ b/src/pages/resource/FederationResourcePage/FederationResourceView.js
@@ -422,7 +422,7 @@ const FederationResourceView = ({data}) => {
     const navItems = buildFederationNavItems(data.navTitles, federationContent);
     if (federationContent) {
         sectionList.current = federationContent.map((element, i) => {
-            return sectionList.current[i] || createRef()
+            return sectionList.current[i] || createRef();
         });
     }
     const handleScroll = () => {
@@ -497,9 +497,9 @@ const FederationResourceView = ({data}) => {
                         {
                             navItems.map((navItem, navIdx) => {
                                 const navKey = `nav_${navIdx}`;
-                                const className = selectedNavTitle === navItem.id
-                                    ? 'navTopicItem selected'
-                                    : 'navTopicItem';
+                                const className = navItem.isSubtitle
+                                    ? (selectedNavTitle === navItem.id ? 'navTopicItem selected subtitle' : 'navTopicItem subtitle')
+                                    : (selectedNavTitle === navItem.id ? 'navTopicItem selected' : 'navTopicItem');
                                 return (
                                     <div name={navItem.id} className={className} key={navKey} onClick={handleClickEvent}>{navItem.label}</div>
                                 );
@@ -517,6 +517,44 @@ const FederationResourceView = ({data}) => {
                         {
                             federationContent && federationContent.map((federationItem, mciid) => {
                                 const mcikey = `federation_${mciid}`;
+                                const hasSubtopics = Array.isArray(federationItem.list) && federationItem.list.length > 0;
+                                const dataAccessImg = federationItem.id
+                                    && federationItem.id.includes('Data_Access')
+                                    && data.CCDI_Federation_Data_Access;
+
+                                if (hasSubtopics) {
+                                    return (
+                                        <div key={mcikey}>
+                                            <div id={federationItem.id} className='mciTitle'>{federationItem.topic && federationItem.topic}</div>
+                                            <div id={federationItem.id} name={mciid} className='mciTitleMobile sectionCollapse' onClick={handleCollapseSection}>{federationItem.topic && federationItem.topic}</div>
+                                            <div className="mciSection mobileCollapse" ref={sectionList.current[mciid]}>
+                                                {federationItem.content && (
+                                                    <div className='mciContentContainer'>
+                                                        <FederationMarkdown>{federationItem.content}</FederationMarkdown>
+                                                    </div>
+                                                )}
+                                                {federationItem.content && <div style={{height: '40px'}} />}
+                                                {
+                                                    federationItem.list.map((listItem, idx) => {
+                                                        const listItemKey = `listItem_${mciid}_${idx}`;
+                                                        return (
+                                                            <div key={listItemKey}>
+                                                                <div id={listItem.id} className='mciSubtitle'>{listItem.subtopic && listItem.subtopic}</div>
+                                                                <div className='mciContentContainer'>
+                                                                    {listItem.content && (
+                                                                        <FederationMarkdown>{listItem.content}</FederationMarkdown>
+                                                                    )}
+                                                                </div>
+                                                                {listItem.content && <div style={{height: '40px'}} />}
+                                                            </div>
+                                                        );
+                                                    })
+                                                }
+                                            </div>
+                                        </div>
+                                    );
+                                }
+
                                 return (
                                     <div key={mcikey}>
                                         <div id={federationItem.id} className='mciTitle'>{federationItem.topic && federationItem.topic}</div>
@@ -527,8 +565,7 @@ const FederationResourceView = ({data}) => {
                                                     <FederationMarkdown>{federationItem.content}</FederationMarkdown>
                                                 )}
 
-                                                {federationItem.id && federationItem.id.includes('Data_Access')
-                                                && data.CCDI_Federation_Data_Access && (
+                                                {dataAccessImg && (
                                                 <div style={{ justifyContent: 'center', display: 'flex'}}>
                                                     <img className="federationImg" src={data.CCDI_Federation_Data_Access} alt="Infographic displaying the CCDI Federation Service ecosystem. Users can directly access individual source nodes (KidsFirst, PCDC, St. Jude Cloud, Treehouse) or utilize the aggregation capabilities of the Federation Service to query data across all nodes simultaneously."/>
                                                 </div>
@@ -537,7 +574,7 @@ const FederationResourceView = ({data}) => {
                                             {federationItem.content && <div style={{height: '40px'}} />}
                                         </div>
                                     </div>
-                                )
+                                );
                             })
                         }
                     </div>

--- a/src/pages/resource/FederationResourcePage/parseFederationMarkdown.js
+++ b/src/pages/resource/FederationResourcePage/parseFederationMarkdown.js
@@ -20,8 +20,9 @@ export function topicToSectionId(topic) {
     .replace(/[^a-zA-Z0-9_]/g, '');
 }
 
-function parseHeadingLine(line) {
-  const m = line.match(/^##\s+(.+)$/);
+function parseHeadingLine(line, level) {
+  const re = level === 2 ? /^##\s+(.+)$/ : /^###\s+(.+)$/;
+  const m = line.match(re);
   if (!m) return null;
   const rawInner = m[1];
   const title = stripMarkdownHeadingBraceId(rawInner);
@@ -80,7 +81,7 @@ function splitH2(rest) {
           body: trimMd(cur.lines.join('\n')),
         });
       }
-      const p = parseHeadingLine(line);
+      const p = parseHeadingLine(line, 2);
       const rawH2 = line.replace(/^##\s+/, '').trim();
       cur = p
         ? { title: p.title, id: p.id, lines: [] }
@@ -103,30 +104,99 @@ function splitH2(rest) {
   return topics;
 }
 
+function pushH3Sub(subs, cur) {
+  subs.push({
+    subtopic: cur.subtopic,
+    id: cur.id,
+    body: cur.lines.join('\n'),
+  });
+}
+
 /**
- * Builds ordered side-nav entries from front matter navTitles.
+ * Split a topic body into optional leading content (before first ###) and H3 subs.
+ */
+function splitTopicBody(topicBody) {
+  if (!topicBody || !topicBody.trim()) {
+    return { content: '', subs: [] };
+  }
+  const lines = topicBody.split('\n');
+  const leading = [];
+  const subs = [];
+  let cur = null;
+  let seenH3 = false;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^###\s/.test(line)) {
+      seenH3 = true;
+      if (cur) {
+        pushH3Sub(subs, cur);
+      }
+      const p = parseHeadingLine(line, 3);
+      const rawH3 = line.replace(/^###\s+/, '').trim();
+      cur = p
+        ? { subtopic: p.title, id: p.id, lines: [] }
+        : {
+            subtopic: stripMarkdownHeadingBraceId(rawH3),
+            id: topicToSectionId(rawH3),
+            lines: [],
+          };
+    } else if (cur) {
+      cur.lines.push(line);
+    } else if (!seenH3) {
+      leading.push(line);
+    }
+  }
+  if (cur) {
+    pushH3Sub(subs, cur);
+  }
+
+  return {
+    content: trimMd(leading.join('\n')),
+    subs,
+  };
+}
+
+/**
+ * Builds ordered side-nav entries from front matter navTitles (topics + subtopics).
  * Falls back to document order when navTitles is omitted.
  */
 export function buildFederationNavItems(navTitles, federationContent) {
   const content = Array.isArray(federationContent) ? federationContent : [];
   if (!Array.isArray(navTitles) || navTitles.length === 0) {
-    return content.map((topic) => ({
-      id: topic.id,
-      label: topic.topic,
-      isSubtitle: false,
-    }));
+    const items = [];
+    content.forEach((topic) => {
+      items.push({ id: topic.id, label: topic.topic, isSubtitle: false });
+      (topic.list || []).forEach((sub) => {
+        items.push({ id: sub.id, label: sub.subtopic, isSubtitle: true });
+      });
+    });
+    return items;
   }
 
   const topicByKey = new Map();
+  const subByKey = new Map();
   content.forEach((topic) => {
     topicByKey.set(normalizeNavTitleKey(topic.topic), topic);
+    (topic.list || []).forEach((sub) => {
+      subByKey.set(normalizeNavTitleKey(sub.subtopic), { topic, sub });
+    });
   });
 
   return navTitles
     .map((title) => {
-      const topic = topicByKey.get(normalizeNavTitleKey(title));
+      const key = normalizeNavTitleKey(title);
+      const topic = topicByKey.get(key);
       if (topic) {
         return { id: topic.id, label: topic.topic, isSubtitle: false };
+      }
+      const subMatch = subByKey.get(key);
+      if (subMatch) {
+        return {
+          id: subMatch.sub.id,
+          label: subMatch.sub.subtopic,
+          isSubtitle: true,
+        };
       }
       return null;
     })
@@ -163,12 +233,22 @@ export default function parseFederationMarkdown(rawMarkdown) {
         : '';
 
   const topics = splitH2(rest);
-  const federationContent = topics.map((t) => ({
-    id: t.id,
-    topic: t.topic,
-    showInNav: resolveShowInNav(t.topic, navTitleSet),
-    content: t.body,
-  }));
+  const federationContent = topics.map((t) => {
+    const { content, subs } = splitTopicBody(t.body);
+    const list = subs.map((s) => ({
+      id: s.id,
+      subtopic: s.subtopic,
+      showInNav: resolveShowInNav(s.subtopic, navTitleSet),
+      content: trimMd(s.body),
+    }));
+    return {
+      id: t.id,
+      topic: t.topic,
+      showInNav: resolveShowInNav(t.topic, navTitleSet),
+      content,
+      list,
+    };
+  });
 
   return {
     ...restFm,

--- a/tests/fixtures/resource/federationMarkdownSamples.js
+++ b/tests/fixtures/resource/federationMarkdownSamples.js
@@ -9,6 +9,8 @@ CCDI_Federation_Data_Access: https://example.com/federation-diagram.png
 navTitles:
   - Data Access
   - Additional Available Resources
+  - Agent Skill to support streamlined discovery and analysis
+  - Blog
   - Contribute to CCDI Data Federation Resource
   - Contact
 ---
@@ -30,6 +32,12 @@ To access participating nodes API, please click [here](https://cbiit.github.io/c
 ## Additional Available Resources
 
 The CCDI Data Federation Resource offers a suite of resources including the [OpenAPI Specification](https://cbiit.github.io/ccdi-federation-api-aggregation/swagger-aggr.yml).
+
+### Agent Skill to support streamlined discovery and analysis
+The CCDI Data Federation now includes a new Agent Skill.
+
+### Blog
+Read more about the CCDI Federation Agent Skill and API in the blog.
 
 ## Contribute to CCDI Data Federation Resource
 
@@ -54,4 +62,8 @@ Intro paragraph three.
 ## Topic Alpha
 
 Section alpha body.
+
+### Sub Alpha
+
+Sub alpha body.
 `;

--- a/tests/fixtures/resource/resourceDataViewProps.js
+++ b/tests/fixtures/resource/resourceDataViewProps.js
@@ -36,6 +36,7 @@ export const minimalFederationResourceData = {
       id: 'fed_overview',
       topic: 'Federation Overview',
       content: 'Federation body content.',
+      list: [],
     },
   ],
 };

--- a/tests/fixtures/resource/resourceInteractionData.js
+++ b/tests/fixtures/resource/resourceInteractionData.js
@@ -15,11 +15,27 @@ import { defaultPmtlViewData } from './pmtlViewProps';
 
 export const multiTopicFederationData = {
   ...minimalFederationResourceData,
-  navTitles: ['Topic A', 'Data Access', 'Topic B'],
+  navTitles: [
+    'Topic A',
+    'Data Access',
+    'Additional Available Resources',
+    'Agent Skill',
+    'Blog',
+    'Topic B',
+  ],
   federationContent: [
-    { id: 'fed_a', topic: 'Topic A', content: 'Section A' },
-    { id: 'Data_Access', topic: 'Data Access', content: 'Access details' },
-    { id: 'fed_b', topic: 'Topic B', content: 'Section B' },
+    { id: 'fed_a', topic: 'Topic A', content: 'Section A', list: [] },
+    { id: 'Data_Access', topic: 'Data Access', content: 'Access details', list: [] },
+    {
+      id: 'Additional_Available_Resources',
+      topic: 'Additional Available Resources',
+      content: 'Resources intro',
+      list: [
+        { id: 'Agent_Skill', subtopic: 'Agent Skill', content: 'Agent Skill body' },
+        { id: 'Blog', subtopic: 'Blog', content: 'Blog body' },
+      ],
+    },
+    { id: 'fed_b', topic: 'Topic B', content: 'Section B', list: [] },
   ],
   CCDI_Federation_Data_Access: '/test-federation-infographic.png',
 };

--- a/tests/pages/resource/FederationResourcePage/federationResourceView.test.js
+++ b/tests/pages/resource/FederationResourcePage/federationResourceView.test.js
@@ -21,6 +21,7 @@ import { minimalFederationResourceData } from '../../../fixtures/resource/resour
 import { multiTopicFederationData } from '../../../fixtures/resource/resourceInteractionData';
 import {
   clickTopicNav,
+  clickSubtopicNav,
   triggerResourceScroll,
   toggleMobileSection,
 } from '../shared/resourceViewTestUtils';
@@ -99,6 +100,20 @@ describe('FederationResourceView', () => {
 
       const topicB = clickTopicNav('Topic B');
       expect(topicB).toHaveClass('selected');
+      expect(scrollTo).toHaveBeenCalled();
+    });
+
+    it('should render nested subtopics and scroll when a subtitle nav item is clicked', () => {
+      const scrollTo = jest.fn();
+      window.scrollTo = scrollTo;
+      renderFederationView(multiTopicFederationData);
+
+      expect(screen.getAllByText('Agent Skill').length).toBeGreaterThan(0);
+      expect(screen.getByText('Agent Skill body')).toBeInTheDocument();
+
+      const agentSkillNav = clickSubtopicNav('Agent Skill');
+      expect(agentSkillNav).toHaveClass('selected');
+      expect(agentSkillNav).toHaveClass('subtitle');
       expect(scrollTo).toHaveBeenCalled();
     });
 

--- a/tests/pages/resource/FederationResourcePage/parseFederationMarkdown.test.js
+++ b/tests/pages/resource/FederationResourcePage/parseFederationMarkdown.test.js
@@ -21,7 +21,7 @@ describe('parseFederationMarkdown', () => {
     expect(data.federationIntroText).toContain('pull data from across various resources');
     expect(data.federationIntroText).toContain('piloting data federation');
     expect(data.federationIntroText).toContain('will expand as more organizations');
-    expect(data.navTitles).toHaveLength(4);
+    expect(data.navTitles).toHaveLength(6);
     expect(data.federationContent).toHaveLength(4);
 
     const dataAccess = data.federationContent[0];
@@ -29,27 +29,55 @@ describe('parseFederationMarkdown', () => {
     expect(dataAccess.id).toBe('Data_Access');
     expect(dataAccess.content).toContain('deidentified individual-level data');
     expect(dataAccess.content).toContain('ccdi-federation-api-aggregation');
+    expect(dataAccess.list).toEqual([]);
   });
 
-  it('should build side nav from navTitles in order', () => {
+  it('should parse ### headings as nested subtopics under a topic', () => {
+    const data = parseFederationMarkdown(sampleFederationMarkdownRaw);
+    const resources = data.federationContent[1];
+
+    expect(resources.topic).toBe('Additional Available Resources');
+    expect(resources.content).toContain('OpenAPI Specification');
+    expect(resources.list).toHaveLength(2);
+    expect(resources.list[0].subtopic).toBe(
+      'Agent Skill to support streamlined discovery and analysis',
+    );
+    expect(resources.list[0].id).toBe(
+      'Agent_Skill_to_support_streamlined_discovery_and_analysis',
+    );
+    expect(resources.list[0].content).toContain('Agent Skill');
+    expect(resources.list[1].subtopic).toBe('Blog');
+    expect(resources.list[1].id).toBe('Blog');
+    expect(resources.list[1].content).toContain('blog');
+  });
+
+  it('should build side nav from navTitles including subtitle entries', () => {
     const data = parseFederationMarkdown(sampleFederationMarkdownRaw);
     const navItems = buildFederationNavItems(data.navTitles, data.federationContent);
 
     expect(navItems.map((item) => item.label)).toEqual([
       'Data Access',
       'Additional Available Resources',
+      'Agent Skill to support streamlined discovery and analysis',
+      'Blog',
       'Contribute to CCDI Data Federation Resource',
       'Contact',
     ]);
     expect(navItems[0].id).toBe('Data_Access');
+    expect(navItems[0].isSubtitle).toBe(false);
+    expect(navItems[2].isSubtitle).toBe(true);
+    expect(navItems[3].isSubtitle).toBe(true);
   });
 
   it('should fall back to document order when navTitles is omitted', () => {
     const data = parseFederationMarkdown(sampleFederationMarkdownNoNavTitles);
     const navItems = buildFederationNavItems(data.navTitles, data.federationContent);
 
-    expect(navItems).toHaveLength(1);
+    expect(navItems).toHaveLength(2);
     expect(navItems[0].label).toBe('Topic Alpha');
+    expect(navItems[0].isSubtitle).toBe(false);
+    expect(navItems[1].label).toBe('Sub Alpha');
+    expect(navItems[1].isSubtitle).toBe(true);
   });
 
   it('should split intro into paragraphs before first h2', () => {
@@ -72,6 +100,7 @@ describe('parseFederationMarkdown', () => {
     const parsed = parseFederationMarkdown(bom);
     expect(parsed.title).toBe('BOM Federation');
     expect(parsed.federationContent[0].content).toBe('Body.');
+    expect(parsed.federationContent[0].list).toEqual([]);
   });
 });
 


### PR DESCRIPTION
- Updated `FederationResourceView` to render nested subtopics in the navigation.
- Modified `parseFederationMarkdown` to handle parsing of subtopics from markdown.
- Adjusted `buildFederationNavItems` to include subtopics in the navigation structure.
- Added tests to verify rendering and navigation of subtopics.
- Updated sample markdown and test data to reflect new subtopic structure.