### PR TITLE
Add FederationContentSegments component for rendering markdown and wi…

### DIFF
--- a/src/pages/resource/FederationResourcePage/FederationContentSegments.js
+++ b/src/pages/resource/FederationResourcePage/FederationContentSegments.js
@@ -1,0 +1,93 @@
+import React, { Fragment } from 'react';
+import FederationMarkdown from './FederationMarkdown';
+import MCITable from '../components/MCITable';
+import MCITableMobile from '../components/MCITableMobile';
+import MCISearchTable from '../components/MCISearchTable';
+import MCISearchTableMobile from '../components/MCISearchTableMobile';
+import MCIDiseaseTable from '../components/MCIDiseaseTable';
+import MCIDiseaseTableMobile from '../components/MCIDiseaseTableMobile';
+import MapView from '../../../components/common/mapGenerator';
+import MapViewMobile from '../components/MapViewMobile';
+import { resolveResponsiveImgCaption } from '../MCIResourcePage/parseMciMarkdown';
+
+/**
+ * Renders parsed markdown/widget segments the same way as MCI (tables, map, responsive-img).
+ * `responsive-img` may omit `mobile` — wide is used for both breakpoints.
+ */
+function FederationContentSegments({ segments, pageData }) {
+  if (!Array.isArray(segments) || segments.length === 0) {
+    return null;
+  }
+  return (
+    <>
+      {segments.map((seg, i) => {
+        const k = `federation_seg_${i}`;
+        if (seg.type === 'markdown' && seg.markdown) {
+          return <FederationMarkdown key={k}>{seg.markdown}</FederationMarkdown>;
+        }
+        if (seg.type !== 'widget' || !seg.data) {
+          return null;
+        }
+        if (seg.widget === 'diseaseTable') {
+          const t = seg.data;
+          return (
+            <Fragment key={k}>
+              <div className="MCIDiseaseTableContainer"><MCIDiseaseTable table={t} /></div>
+              <div className="MCIDiseaseTableMobileContainer"><MCIDiseaseTableMobile table={t} /></div>
+              <p>{t.footer}</p>
+            </Fragment>
+          );
+        }
+        if (seg.widget === 'map') {
+          return (
+            <Fragment key={k}>
+              <div className="MapContainer"><MapView mapData={seg.data} /></div>
+              <div className="MapMobileContainer"><MapViewMobile mapData={seg.data} /></div>
+            </Fragment>
+          );
+        }
+        if (seg.widget === 'table') {
+          const t = seg.data;
+          return (
+            <Fragment key={k}>
+              <div className="MCITableContainer"><MCITable table={t} /></div>
+              <div className="MCITableMobileContainer"><MCITableMobile table={t} /></div>
+              <p>{t.footer}</p>
+            </Fragment>
+          );
+        }
+        if (seg.widget === 'searchTable') {
+          return (
+            <Fragment key={k}>
+              <div className="MCISearchTableContainer"><MCISearchTable table={seg.data} /></div>
+              <div className="MCISearchTableMobileContainer"><MCISearchTableMobile table={seg.data} /></div>
+            </Fragment>
+          );
+        }
+        if (seg.widget === 'responsiveImg') {
+          const ri = seg.data;
+          if (!ri || !ri.wide) {
+            return null;
+          }
+          const mobileSrc = ri.mobile || ri.wide;
+          const riCaption = resolveResponsiveImgCaption(ri, pageData);
+          return (
+            <Fragment key={k}>
+              <img className="ecosystemImg" src={ri.wide} alt={ri.alt || ''} loading="lazy" />
+              <img
+                className="ecosystemImgMobile"
+                src={mobileSrc}
+                alt={ri.altMobile || ri.alt || ''}
+                loading="lazy"
+              />
+              {riCaption ? <div className="ImgCaption">{riCaption}</div> : null}
+            </Fragment>
+          );
+        }
+        return null;
+      })}
+    </>
+  );
+}
+
+export default FederationContentSegments;

--- a/src/pages/resource/FederationResourcePage/FederationMarkdown.js
+++ b/src/pages/resource/FederationResourcePage/FederationMarkdown.js
@@ -9,6 +9,28 @@ function isExternal(href) {
   return href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//');
 }
 
+/** Pair with `.ecosystemImg` / `.ecosystemImgMobile` in FederationResourceView. Prefer ```responsive-img```; this tags rare inline `![alt](url?variant=…)` images. */
+const RESP = {
+  wide: 'ecosystemImg',
+  mobile: 'ecosystemImgMobile',
+  default: 'federation-md-img',
+};
+
+function inlineImgClassName(src) {
+  const raw = String(src || '').trim();
+  if (!raw) return RESP.default;
+  let u;
+  try {
+    u = new URL(raw, 'https://placeholder.local');
+  } catch {
+    return RESP.default;
+  }
+  const p = (u.searchParams.get('variant') || u.searchParams.get('mci') || '').trim().toLowerCase();
+  if (p === 'mobile' || p === 'narrow' || p === 'small') return RESP.mobile;
+  if (p === 'wide' || p === 'desktop' || p === 'large' || p === 'main') return RESP.wide;
+  return RESP.default;
+}
+
 const FederationMarkdown = ({ children }) => {
   if (children === undefined || children === null || children === '') {
     return null;
@@ -31,6 +53,19 @@ const FederationMarkdown = ({ children }) => {
             >
               {linkChildren}
             </a>
+          );
+        },
+        img: ({ node: _i, src, alt, title, ...rest }) => {
+          const cls = inlineImgClassName(src);
+          return (
+            <img
+              {...rest}
+              src={src}
+              alt={alt || ''}
+              title={title}
+              className={cls}
+              loading="lazy"
+            />
           );
         },
       }}

--- a/src/pages/resource/FederationResourcePage/FederationResourceView.js
+++ b/src/pages/resource/FederationResourcePage/FederationResourceView.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, createRef } from 'react';
 import styled from 'styled-components';
 import FederationMarkdown from './FederationMarkdown';
+import FederationContentSegments from './FederationContentSegments';
 import { buildFederationNavItems } from './parseFederationMarkdown';
 import headerImg from '../../../assets/resources/Federation_Header.png';
 import exportIcon from '../../../assets/resources/Explore_Icon.svg';
@@ -9,6 +10,10 @@ import arrowDownIcon from '../../../assets/icons/Arrow_Down.svg';
 // import { federationContent, introText } from '../../../bento/federationData';
 import exportIconBlue from '../../../assets/icons/Export_Icon.svg';
 // import ccdiDataAccessImg from '../../../assets/resources/Federation_CCDI_Data_Access.png';
+
+function hasSegments(segments) {
+    return Array.isArray(segments) && segments.length > 0;
+}
 
 
 const FederationResourceContainer = styled.div`
@@ -361,6 +366,52 @@ const FederationResourceBody = styled.div`
         max-width: 467px;
     }
 
+    .MCITableMobileContainer {
+        display: none;
+    }
+
+    .MCISearchTableMobileContainer {
+        display: none;
+    }
+
+    .ecosystemImg {
+        width: 100%;
+    }
+
+    .ecosystemImgMobile {
+        display: none;
+    }
+
+    .mciContentContainer .federation-md-img {
+        max-width: 100%;
+        height: auto;
+        display: block;
+    }
+
+    .introContainer .federation-md-img {
+        max-width: 100%;
+        height: auto;
+    }
+
+    .ImgCaption {
+        color: #000;
+        font-family: Inter;
+        font-size: 14px;
+        font-style: italic;
+        font-weight: 500;
+        line-height: 22px;
+        letter-spacing: -0.28px;
+        padding: 10px 35px;
+    }
+
+    .MapMobileContainer {
+        display: none;
+    }
+
+    .MCIDiseaseTableMobileContainer {
+        display: none;
+    }
+
     .donutContainer {
         display: flex;
     }
@@ -379,6 +430,39 @@ const FederationResourceBody = styled.div`
             margin: 120px 0 0 150px;
         }
 
+    }
+
+    @media (max-width: 1023px) {
+        .MCITableContainer {
+            display: none;
+        }
+        .MCITableMobileContainer {
+            display: block;
+        }
+
+        .MCISearchTableContainer {
+            display: none;
+        }
+
+        .MCISearchTableMobileContainer {
+            display: block;
+        }
+
+        .MapContainer {
+            display: none;
+        }
+
+        .MapMobileContainer {
+            display: block;
+        }
+
+        .MCIDiseaseTableContainer {
+            display: none;
+        }
+
+        .MCIDiseaseTableMobileContainer {
+            display: block;
+        }
     }
 
     @media (max-width: 767px) {
@@ -410,6 +494,16 @@ const FederationResourceBody = styled.div`
 
         .mciContentContainer {
             margin-left: 0;
+        }
+
+        .ecosystemImg {
+            display: none;
+        }
+
+        .ecosystemImgMobile {
+            display: block;
+            width: 310px;
+            margin: 10px auto;
         }
     }
 `;
@@ -528,12 +622,12 @@ const FederationResourceView = ({data}) => {
                                             <div id={federationItem.id} className='mciTitle'>{federationItem.topic && federationItem.topic}</div>
                                             <div id={federationItem.id} name={mciid} className='mciTitleMobile sectionCollapse' onClick={handleCollapseSection}>{federationItem.topic && federationItem.topic}</div>
                                             <div className="mciSection mobileCollapse" ref={sectionList.current[mciid]}>
-                                                {federationItem.content && (
+                                                {hasSegments(federationItem.segments) && (
                                                     <div className='mciContentContainer'>
-                                                        <FederationMarkdown>{federationItem.content}</FederationMarkdown>
+                                                        <FederationContentSegments segments={federationItem.segments} pageData={data} />
                                                     </div>
                                                 )}
-                                                {federationItem.content && <div style={{height: '40px'}} />}
+                                                {hasSegments(federationItem.segments) && <div style={{height: '40px'}} />}
                                                 {
                                                     federationItem.list.map((listItem, idx) => {
                                                         const listItemKey = `listItem_${mciid}_${idx}`;
@@ -541,11 +635,9 @@ const FederationResourceView = ({data}) => {
                                                             <div key={listItemKey}>
                                                                 <div id={listItem.id} className='mciSubtitle'>{listItem.subtopic && listItem.subtopic}</div>
                                                                 <div className='mciContentContainer'>
-                                                                    {listItem.content && (
-                                                                        <FederationMarkdown>{listItem.content}</FederationMarkdown>
-                                                                    )}
+                                                                    <FederationContentSegments segments={listItem.segments} pageData={data} />
                                                                 </div>
-                                                                {listItem.content && <div style={{height: '40px'}} />}
+                                                                {hasSegments(listItem.segments) && <div style={{height: '40px'}} />}
                                                             </div>
                                                         );
                                                     })
@@ -561,9 +653,7 @@ const FederationResourceView = ({data}) => {
                                         <div id={federationItem.id} name={mciid} className='mciTitleMobile sectionCollapse' onClick={handleCollapseSection}>{federationItem.topic && federationItem.topic}</div>
                                         <div className="mciSection mobileCollapse" ref={sectionList.current[mciid]}>
                                             <div className='mciContentContainer'>
-                                                {federationItem.content && (
-                                                    <FederationMarkdown>{federationItem.content}</FederationMarkdown>
-                                                )}
+                                                <FederationContentSegments segments={federationItem.segments} pageData={data} />
 
                                                 {dataAccessImg && (
                                                 <div style={{ justifyContent: 'center', display: 'flex'}}>
@@ -571,7 +661,7 @@ const FederationResourceView = ({data}) => {
                                                 </div>
                                                 )}
                                             </div>
-                                            {federationItem.content && <div style={{height: '40px'}} />}
+                                            {hasSegments(federationItem.segments) && <div style={{height: '40px'}} />}
                                         </div>
                                     </div>
                                 );

--- a/src/pages/resource/FederationResourcePage/parseFederationMarkdown.js
+++ b/src/pages/resource/FederationResourcePage/parseFederationMarkdown.js
@@ -1,6 +1,7 @@
 import matter from 'gray-matter';
 import {
   buildNavTitleSet,
+  buildSegments,
   normalizeNavTitleKey,
   resolveShowInNav,
 } from '../MCIResourcePage/parseMciMarkdown';
@@ -235,17 +236,22 @@ export default function parseFederationMarkdown(rawMarkdown) {
   const topics = splitH2(rest);
   const federationContent = topics.map((t) => {
     const { content, subs } = splitTopicBody(t.body);
-    const list = subs.map((s) => ({
-      id: s.id,
-      subtopic: s.subtopic,
-      showInNav: resolveShowInNav(s.subtopic, navTitleSet),
-      content: trimMd(s.body),
-    }));
+    const list = subs.map((s) => {
+      const bodyMd = trimMd(s.body);
+      return {
+        id: s.id,
+        subtopic: s.subtopic,
+        showInNav: resolveShowInNav(s.subtopic, navTitleSet),
+        content: bodyMd,
+        segments: buildSegments(bodyMd),
+      };
+    });
     return {
       id: t.id,
       topic: t.topic,
       showInNav: resolveShowInNav(t.topic, navTitleSet),
       content,
+      segments: buildSegments(content),
       list,
     };
   });

--- a/src/pages/resource/MCIResourcePage/parseMciMarkdown.js
+++ b/src/pages/resource/MCIResourcePage/parseMciMarkdown.js
@@ -204,10 +204,11 @@ function trimMd(s) {
 }
 
 /**
- * Walks a ### subtopic body in source order: markdown runs and ` ```${lang}` widgets alternate.
+ * Walks markdown body in source order: markdown runs and fenced widgets alternate.
+ * Widgets: mci-disease-table, mci-map, mci-search-table, mci-table, responsive-img.
  * @returns {Array<{ type: 'markdown', markdown: string }|{ type: 'widget', widget: string, data: * }>}
  */
-function buildSegments(body) {
+export function buildSegments(body) {
   const rawText = String(body || '');
   const re = new RegExp(
     '```' + WIDGET_LANG + '\\s*\\n([\\s\\S]*?)```',

--- a/tests/fixtures/resource/federationMarkdownSamples.js
+++ b/tests/fixtures/resource/federationMarkdownSamples.js
@@ -36,6 +36,12 @@ The CCDI Data Federation Resource offers a suite of resources including the [Ope
 ### Agent Skill to support streamlined discovery and analysis
 The CCDI Data Federation now includes a new Agent Skill.
 
+\`\`\`responsive-img
+wide: 'https://example.com/federation-agent-skill.png'
+alt: 'test'
+Caption: ""
+\`\`\`
+
 ### Blog
 Read more about the CCDI Federation Agent Skill and API in the blog.
 

--- a/tests/fixtures/resource/resourceDataViewProps.js
+++ b/tests/fixtures/resource/resourceDataViewProps.js
@@ -36,6 +36,7 @@ export const minimalFederationResourceData = {
       id: 'fed_overview',
       topic: 'Federation Overview',
       content: 'Federation body content.',
+      segments: [{ type: 'markdown', markdown: 'Federation body content.' }],
       list: [],
     },
   ],

--- a/tests/fixtures/resource/resourceInteractionData.js
+++ b/tests/fixtures/resource/resourceInteractionData.js
@@ -24,18 +24,47 @@ export const multiTopicFederationData = {
     'Topic B',
   ],
   federationContent: [
-    { id: 'fed_a', topic: 'Topic A', content: 'Section A', list: [] },
-    { id: 'Data_Access', topic: 'Data Access', content: 'Access details', list: [] },
+    {
+      id: 'fed_a',
+      topic: 'Topic A',
+      content: 'Section A',
+      segments: [{ type: 'markdown', markdown: 'Section A' }],
+      list: [],
+    },
+    {
+      id: 'Data_Access',
+      topic: 'Data Access',
+      content: 'Access details',
+      segments: [{ type: 'markdown', markdown: 'Access details' }],
+      list: [],
+    },
     {
       id: 'Additional_Available_Resources',
       topic: 'Additional Available Resources',
       content: 'Resources intro',
+      segments: [{ type: 'markdown', markdown: 'Resources intro' }],
       list: [
-        { id: 'Agent_Skill', subtopic: 'Agent Skill', content: 'Agent Skill body' },
-        { id: 'Blog', subtopic: 'Blog', content: 'Blog body' },
+        {
+          id: 'Agent_Skill',
+          subtopic: 'Agent Skill',
+          content: 'Agent Skill body',
+          segments: [{ type: 'markdown', markdown: 'Agent Skill body' }],
+        },
+        {
+          id: 'Blog',
+          subtopic: 'Blog',
+          content: 'Blog body',
+          segments: [{ type: 'markdown', markdown: 'Blog body' }],
+        },
       ],
     },
-    { id: 'fed_b', topic: 'Topic B', content: 'Section B', list: [] },
+    {
+      id: 'fed_b',
+      topic: 'Topic B',
+      content: 'Section B',
+      segments: [{ type: 'markdown', markdown: 'Section B' }],
+      list: [],
+    },
   ],
   CCDI_Federation_Data_Access: '/test-federation-infographic.png',
 };

--- a/tests/pages/resource/FederationResourcePage/parseFederationMarkdown.test.js
+++ b/tests/pages/resource/FederationResourcePage/parseFederationMarkdown.test.js
@@ -46,9 +46,31 @@ describe('parseFederationMarkdown', () => {
       'Agent_Skill_to_support_streamlined_discovery_and_analysis',
     );
     expect(resources.list[0].content).toContain('Agent Skill');
+    expect(resources.list[0].segments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'markdown' }),
+        expect.objectContaining({
+          type: 'widget',
+          widget: 'responsiveImg',
+          data: expect.objectContaining({
+            wide: 'https://example.com/federation-agent-skill.png',
+            alt: 'test',
+            Caption: '',
+          }),
+        }),
+      ]),
+    );
     expect(resources.list[1].subtopic).toBe('Blog');
     expect(resources.list[1].id).toBe('Blog');
     expect(resources.list[1].content).toContain('blog');
+  });
+
+  it('should parse topic bodies into markdown/widget segments', () => {
+    const data = parseFederationMarkdown(sampleFederationMarkdownRaw);
+    const dataAccess = data.federationContent[0];
+    expect(dataAccess.segments).toHaveLength(1);
+    expect(dataAccess.segments[0].type).toBe('markdown');
+    expect(dataAccess.segments[0].markdown).toContain('deidentified individual-level data');
   });
 
   it('should build side nav from navTitles including subtitle entries', () => {


### PR DESCRIPTION
…dget segments

- Introduced `FederationContentSegments` to handle various segment types including markdown, disease tables, maps, and responsive images.
- Updated `FederationMarkdown` to support inline image classes for better responsiveness.
- Enhanced `FederationResourceView` to utilize the new segments component for rendering content.
- Modified `parseFederationMarkdown` to build segments from markdown content.
- Added tests to ensure proper parsing and rendering of segments.